### PR TITLE
Create full debug information for all build types

### DIFF
--- a/GeUtilities.Tests/GeUtilities.Tests.csproj
+++ b/GeUtilities.Tests/GeUtilities.Tests.csproj
@@ -11,6 +11,11 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />

--- a/GeUtilities/GeUtilities.csproj
+++ b/GeUtilities/GeUtilities.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DebugType>none</DebugType>
-    <DebugSymbols>false</DebugSymbols>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
For the build type "Release", it was not set to create `Full` debug information. This causes some issues generating code coverage, as OpenCover leverages full debug information.