### PR TITLE
Simplified constructors

### DIFF
--- a/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
@@ -42,8 +42,7 @@ namespace GeUtilities.Tests.TBEDParser
                     assembly: Assemblies.hg19,
                     defaultValue: 1E-8,
                     pValueFormat: PValueFormat.SameAsInput,
-                    dropPeakIfInvalidValue: true,
-                    hashFunction: HashFunction.FNV);
+                    dropPeakIfInvalidValue: true);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert
@@ -71,8 +70,7 @@ namespace GeUtilities.Tests.TBEDParser
                     assembly: Assemblies.hg19,
                     defaultValue: 1E-8,
                     pValueFormat: PValueFormat.SameAsInput,
-                    dropPeakIfInvalidValue: true,
-                    hashFunction: HashFunction.FNV);
+                    dropPeakIfInvalidValue: true);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
@@ -39,7 +39,6 @@ namespace GeUtilities.Tests.TBEDParser
                 // Act
                 BEDParser parser = new BEDParser(
                     testFile.TempFilePath,
-                    defaultValue: 1E-8,
                     pValueFormat: PValueFormat.SameAsInput,
                     dropPeakIfInvalidValue: true);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
@@ -66,7 +65,6 @@ namespace GeUtilities.Tests.TBEDParser
                     valueColumn: columns.ValueColumn,
                     strandColumn: columns.StrandColumn,
                     summitColumn: columns.SummitColumn,
-                    defaultValue: 1E-8,
                     pValueFormat: PValueFormat.SameAsInput,
                     dropPeakIfInvalidValue: true);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];

--- a/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
@@ -43,9 +43,6 @@ namespace GeUtilities.Tests.TBEDParser
                     defaultValue: 1E-8,
                     pValueFormat: PValueFormat.SameAsInput,
                     dropPeakIfInvalidValue: true,
-                    startOffset: 0,
-                    readOnlyValidChrs: true,
-                    maxLinesToRead: 1,
                     hashFunction: HashFunction.FNV);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
@@ -75,9 +72,6 @@ namespace GeUtilities.Tests.TBEDParser
                     defaultValue: 1E-8,
                     pValueFormat: PValueFormat.SameAsInput,
                     dropPeakIfInvalidValue: true,
-                    startOffset: 0,
-                    readOnlyValidChrs: true,
-                    maxLinesToRead: 1,
                     hashFunction: HashFunction.FNV);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 

--- a/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
@@ -65,8 +65,7 @@ namespace GeUtilities.Tests.TBEDParser
                     valueColumn: columns.ValueColumn,
                     strandColumn: columns.StrandColumn,
                     summitColumn: columns.SummitColumn,
-                    pValueFormat: PValueFormat.SameAsInput,
-                    dropPeakIfInvalidValue: true);
+                    pValueFormat: PValueFormat.SameAsInput);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
@@ -39,7 +39,6 @@ namespace GeUtilities.Tests.TBEDParser
                 // Act
                 BEDParser parser = new BEDParser(
                     testFile.TempFilePath,
-                    assembly: Assemblies.hg19,
                     defaultValue: 1E-8,
                     pValueFormat: PValueFormat.SameAsInput,
                     dropPeakIfInvalidValue: true);
@@ -67,7 +66,6 @@ namespace GeUtilities.Tests.TBEDParser
                     valueColumn: columns.ValueColumn,
                     strandColumn: columns.StrandColumn,
                     summitColumn: columns.SummitColumn,
-                    assembly: Assemblies.hg19,
                     defaultValue: 1E-8,
                     pValueFormat: PValueFormat.SameAsInput,
                     dropPeakIfInvalidValue: true);

--- a/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/BEDParser/ConcreteClassArguments.cs
@@ -39,7 +39,6 @@ namespace GeUtilities.Tests.TBEDParser
                 // Act
                 BEDParser parser = new BEDParser(
                     testFile.TempFilePath,
-                    pValueFormat: PValueFormat.SameAsInput,
                     dropPeakIfInvalidValue: true);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
@@ -64,8 +63,7 @@ namespace GeUtilities.Tests.TBEDParser
                     nameColumn: columns.NameColumn,
                     valueColumn: columns.ValueColumn,
                     strandColumn: columns.StrandColumn,
-                    summitColumn: columns.SummitColumn,
-                    pValueFormat: PValueFormat.SameAsInput);
+                    summitColumn: columns.SummitColumn);
                 var parsedPeak = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/DefaultArguments.cs
+++ b/GeUtilities.Tests/BEDParser/DefaultArguments.cs
@@ -35,13 +35,14 @@ namespace GeUtilities.Tests.TBEDParser
         [InlineData(1, 0)]
         [InlineData(2, 0)]
         [InlineData(2, 2)]
-        public void AvoidHeader(int headerCount, byte startOffset)
+        public void AvoidHeader(int headerCount, byte readOffset)
         {
             // Arrange
             using (TempFileCreator testFile = new TempFileCreator(new Columns(), headerLineCount: headerCount))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, startOffset: startOffset);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.ReadOffset = readOffset;
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/DefaultArguments.cs
+++ b/GeUtilities.Tests/BEDParser/DefaultArguments.cs
@@ -21,7 +21,7 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator())
             {
                 // Act
-                BEDParser<ChIPSeqPeak> bedParser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, dropPeakIfInvalidValue: true);
+                BEDParser<ChIPSeqPeak> bedParser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
                 var parsedPeak = bedParser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/Features.cs
+++ b/GeUtilities.Tests/BEDParser/Features.cs
@@ -38,7 +38,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, dropPeakIfInvalidValue: true);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.DropPeakIfInvalidValue = true;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -54,7 +55,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, dropPeakIfInvalidValue: false);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.DropPeakIfInvalidValue = false;
                 parser.DefaultValue = defaultValue;
                 var parsedData = parser.Parse();
 
@@ -77,8 +79,8 @@ namespace GeUtilities.Tests.TBEDParser
                     leftEndColumn: columns.LeftColumn,
                     rightEndColumn: columns.RightColumn,
                     nameColumn: columns.NameColumn,
-                    valueColumn: 9,
-                    dropPeakIfInvalidValue: true);
+                    valueColumn: 9);
+                parser.DropPeakIfInvalidValue = true;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -100,8 +102,8 @@ namespace GeUtilities.Tests.TBEDParser
                     leftEndColumn: columns.LeftColumn,
                     rightEndColumn: columns.RightColumn,
                     nameColumn: columns.NameColumn,
-                    valueColumn: 9,
-                    dropPeakIfInvalidValue: false);
+                    valueColumn: 9);
+                parser.DropPeakIfInvalidValue = false;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -181,8 +183,8 @@ namespace GeUtilities.Tests.TBEDParser
                     leftEndColumn: columns.LeftColumn,
                     rightEndColumn: columns.RightColumn,
                     nameColumn: 12,
-                    valueColumn: columns.ValueColumn,
-                    dropPeakIfInvalidValue: false);
+                    valueColumn: columns.ValueColumn);
+                parser.DropPeakIfInvalidValue = false;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -223,8 +225,8 @@ namespace GeUtilities.Tests.TBEDParser
                     leftEndColumn: columns.LeftColumn,
                     rightEndColumn: columns.RightColumn,
                     nameColumn: columns.NameColumn,
-                    valueColumn: 9,
-                    dropPeakIfInvalidValue: true);
+                    valueColumn: 9);
+                parser.DropPeakIfInvalidValue = true;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -334,7 +336,7 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator("             "))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, dropPeakIfInvalidValue: true);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/Features.cs
+++ b/GeUtilities.Tests/BEDParser/Features.cs
@@ -190,16 +190,17 @@ namespace GeUtilities.Tests.TBEDParser
         }
 
         [Theory]
-        [InlineData(HashFunction.FNV)]
-        [InlineData(HashFunction.One_at_a_Time)]
-        public void HashFunctions(HashFunction hashFunction)
+        [InlineData(Genometric.GeUtilities.Parsers.HashFunctions.FNV)]
+        [InlineData(Genometric.GeUtilities.Parsers.HashFunctions.One_at_a_Time)]
+        public void HashFunctions(HashFunctions hashFunction)
         {
             // Arrange
             var columns = new Columns();
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, hashFunction: hashFunction);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.HashFunction = hashFunction;
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/Features.cs
+++ b/GeUtilities.Tests/BEDParser/Features.cs
@@ -54,7 +54,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, dropPeakIfInvalidValue: false, defaultValue: defaultValue);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, dropPeakIfInvalidValue: false);
+                parser.DefaultValue = defaultValue;
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/Features.cs
+++ b/GeUtilities.Tests/BEDParser/Features.cs
@@ -241,7 +241,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.Assembly = Assemblies.hg19;
                 parser.ReadOnlyAssemblyChrs = true;
                 var parsedData = parser.Parse();
 
@@ -260,7 +261,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.Assembly = Assemblies.hg19;
                 parser.ReadOnlyAssemblyChrs = true;
                 var parsedData = parser.Parse();
 
@@ -280,7 +282,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.Assembly = Assemblies.hg19;
                 parser.ReadOnlyAssemblyChrs = false;
                 var parsedData = parser.Parse();
 
@@ -297,7 +300,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.Assembly = Assemblies.hg19;
                 parser.ReadOnlyAssemblyChrs = false;
                 var parsedData = parser.Parse();
 

--- a/GeUtilities.Tests/BEDParser/Features.cs
+++ b/GeUtilities.Tests/BEDParser/Features.cs
@@ -112,18 +112,19 @@ namespace GeUtilities.Tests.TBEDParser
         }
 
         [Theory]
-        [InlineData(0.001, 0.001, PValueFormat.SameAsInput)]
-        [InlineData(0.001, 3, PValueFormat.minus1_Log10_pValue)]
-        [InlineData(0.001, 30, PValueFormat.minus10_Log10_pValue)]
-        [InlineData(0.001, 300, PValueFormat.minus100_Log10_pValue)]
-        public void PValueConversion(double originalValue, double convertedValue, PValueFormat pvalueFormat)
+        [InlineData(0.001, 0.001, PValueFormats.SameAsInput)]
+        [InlineData(0.001, 3, PValueFormats.minus1_Log10_pValue)]
+        [InlineData(0.001, 30, PValueFormats.minus10_Log10_pValue)]
+        [InlineData(0.001, 300, PValueFormats.minus100_Log10_pValue)]
+        public void PValueConversion(double originalValue, double convertedValue, PValueFormats pvalueFormat)
         {
             // Arrange
             var columns = new Columns(value: convertedValue);
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, pValueFormat: pvalueFormat);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.PValueFormat = pvalueFormat;
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/BEDParser/Features.cs
+++ b/GeUtilities.Tests/BEDParser/Features.cs
@@ -140,7 +140,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns, peaksCount: numberOfPeaksToWrite))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, maxLinesToRead: numberOfPeaksToRead);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.MaxLinesToRead = numberOfPeaksToRead;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -156,7 +157,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns, peaksCount: 4))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, maxLinesToRead: 0);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.MaxLinesToRead = 0;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -238,7 +240,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19, readOnlyValidChrs: true);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19);
+                parser.ReadOnlyAssemblyChrs = true;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -256,7 +259,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19, readOnlyValidChrs: true);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19);
+                parser.ReadOnlyAssemblyChrs = true;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -275,7 +279,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19, readOnlyValidChrs: false);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19);
+                parser.ReadOnlyAssemblyChrs = false;
                 var parsedData = parser.Parse();
 
                 // Assert
@@ -291,7 +296,8 @@ namespace GeUtilities.Tests.TBEDParser
             using (TempFileCreator testFile = new TempFileCreator(columns))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19, readOnlyValidChrs: false);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: Assemblies.hg19);
+                parser.ReadOnlyAssemblyChrs = false;
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/GTFParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/GTFParser/ConcreteClassArguments.cs
@@ -38,9 +38,6 @@ namespace GeUtilities.Tests.TGTFParser
                 GTFParser parser = new GTFParser(
                     testFile.TempFilePath,
                     assembly: Assemblies.hg19,
-                    readOnlyValidChrs: true,
-                    maxLinesToRead: 1,
-                    startOffset: 0,
                     hashFunction: HashFunction.One_at_a_Time);
                 var parsedFeature = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
@@ -69,9 +66,6 @@ namespace GeUtilities.Tests.TGTFParser
                     frameColumn: columns.FrameColumn,
                     attributeColumn: columns.AttributeColumn,
                     assembly: Assemblies.hg19,
-                    readOnlyValidChrs: true,
-                    maxLinesToRead: 1,
-                    startOffset: 0,
                     hashFunction: HashFunction.One_at_a_Time);
                 var parsedFeature = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 

--- a/GeUtilities.Tests/GTFParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/GTFParser/ConcreteClassArguments.cs
@@ -2,9 +2,7 @@
 // The Genometric organization licenses this file to you under the GNU General Public License v3.0 (GPLv3).
 // See the LICENSE file in the project root for more information.
 
-using Genometric.GeUtilities.IntervalBasedDataParsers.Model.Defaults;
 using Genometric.GeUtilities.Parsers;
-using Genometric.GeUtilities.ReferenceGenomes;
 using Xunit;
 
 namespace GeUtilities.Tests.TGTFParser

--- a/GeUtilities.Tests/GTFParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/GTFParser/ConcreteClassArguments.cs
@@ -37,8 +37,7 @@ namespace GeUtilities.Tests.TGTFParser
                 // Act
                 GTFParser parser = new GTFParser(
                     testFile.TempFilePath,
-                    assembly: Assemblies.hg19,
-                    hashFunction: HashFunction.One_at_a_Time);
+                    assembly: Assemblies.hg19);
                 var parsedFeature = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert
@@ -65,8 +64,7 @@ namespace GeUtilities.Tests.TGTFParser
                     strandColumn: columns.StrandColumn,
                     frameColumn: columns.FrameColumn,
                     attributeColumn: columns.AttributeColumn,
-                    assembly: Assemblies.hg19,
-                    hashFunction: HashFunction.One_at_a_Time);
+                    assembly: Assemblies.hg19);
                 var parsedFeature = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/GTFParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/GTFParser/ConcreteClassArguments.cs
@@ -28,24 +28,6 @@ namespace GeUtilities.Tests.TGTFParser
         }
 
         [Fact]
-        public void PartiallySetArguments()
-        {
-            // Arrange
-            var columns = new Columns();
-            using (TempFileCreator testFile = new TempFileCreator(columns))
-            {
-                // Act
-                GTFParser parser = new GTFParser(
-                    testFile.TempFilePath,
-                    assembly: Assemblies.hg19);
-                var parsedFeature = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
-
-                // Assert
-                Assert.True(parsedFeature.CompareTo(columns.GFeature) == 0);
-            }
-        }
-
-        [Fact]
         public void FullySetArguments()
         {
             // Arrange
@@ -63,8 +45,7 @@ namespace GeUtilities.Tests.TGTFParser
                     scoreColumn: columns.ScoreColumn,
                     strandColumn: columns.StrandColumn,
                     frameColumn: columns.FrameColumn,
-                    attributeColumn: columns.AttributeColumn,
-                    assembly: Assemblies.hg19);
+                    attributeColumn: columns.AttributeColumn);
                 var parsedFeature = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/GTFParser/DefaultArguments.cs
+++ b/GeUtilities.Tests/GTFParser/DefaultArguments.cs
@@ -16,13 +16,14 @@ namespace GeUtilities.Tests.TGTFParser
         [InlineData(1, 0)]
         [InlineData(2, 0)]
         [InlineData(2, 2)]
-        public void AvoidHeader(int headerCount, byte startOffset)
+        public void AvoidHeader(int headerCount, byte readOffset)
         {
             // Arrange
             using (TempFileCreator testFile = new TempFileCreator(new Columns(), headerLineCount: headerCount))
             {
                 // Act
-                GTFParser<GeneralFeature> parser = new GTFParser<GeneralFeature>(testFile.TempFilePath, startOffset: startOffset);
+                GTFParser<GeneralFeature> parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
+                parser.ReadOffset = readOffset;
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/Model/ParsedIntervals.cs
+++ b/GeUtilities.Tests/Model/ParsedIntervals.cs
@@ -72,7 +72,8 @@ namespace GeUtilities.Tests.ModelTests
             using (TempFileCreator testFile = new TempFileCreator(peak))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, assembly: assembly);
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.Assembly = assembly;
                 var parsedBED = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/RefSeqParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/RefSeqParser/ConcreteClassArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.Parsers;
-using Genometric.GeUtilities.ReferenceGenomes;
 using Xunit;
 
 namespace GeUtilities.Tests.TRefSeqParser

--- a/GeUtilities.Tests/RefSeqParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/RefSeqParser/ConcreteClassArguments.cs
@@ -27,24 +27,6 @@ namespace GeUtilities.Tests.TRefSeqParser
         }
 
         [Fact]
-        public void PartiallySetArguments()
-        {
-            // Arrange
-            var columns = new Columns();
-            using (TempFileCreator testFile = new TempFileCreator(columns))
-            {
-                // Act
-                RefSeqParser parser = new RefSeqParser(
-                    testFile.TempFilePath,
-                    assembly: Assemblies.hg19);
-                var parsedGene = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
-
-                // Assert
-                Assert.True(parsedGene.CompareTo(columns.Gene) == 0);
-            }
-        }
-
-        [Fact]
         public void FullySetArguments()
         {
             // Arrange
@@ -59,8 +41,7 @@ namespace GeUtilities.Tests.TRefSeqParser
                     rightEndColumn: columns.RightColumn,
                     refSeqIDColumn: columns.RefSeqIDColumn,
                     geneSymbolColumn: columns.GeneSymbolColumn,
-                    strandColumn: columns.StrandColumn,
-                    assembly: Assemblies.hg19);
+                    strandColumn: columns.StrandColumn);
                 var parsedGene = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/RefSeqParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/RefSeqParser/ConcreteClassArguments.cs
@@ -36,10 +36,7 @@ namespace GeUtilities.Tests.TRefSeqParser
                 // Act
                 RefSeqParser parser = new RefSeqParser(
                     testFile.TempFilePath,
-                    assembly: Assemblies.hg19,
-                    readOnlyValidChrs: true,
-                    startOffset: 0,
-                    maxLinesToRead: 1);
+                    assembly: Assemblies.hg19);
                 var parsedGene = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert
@@ -63,10 +60,7 @@ namespace GeUtilities.Tests.TRefSeqParser
                     refSeqIDColumn: columns.RefSeqIDColumn,
                     geneSymbolColumn: columns.GeneSymbolColumn,
                     strandColumn: columns.StrandColumn,
-                    assembly: Assemblies.hg19,
-                    readOnlyValidChrs: true,
-                    startOffset: 0,
-                    maxLinesToRead: 1);
+                    assembly: Assemblies.hg19);
                 var parsedGene = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/RefSeqParser/DefaultArguments.cs
+++ b/GeUtilities.Tests/RefSeqParser/DefaultArguments.cs
@@ -4,7 +4,6 @@
 
 using Genometric.GeUtilities.IntervalBasedDataParsers.Model.Defaults;
 using Genometric.GeUtilities.Parsers;
-using System;
 using Xunit;
 
 namespace GeUtilities.Tests.TRefSeqParser

--- a/GeUtilities.Tests/RefSeqParser/DefaultArguments.cs
+++ b/GeUtilities.Tests/RefSeqParser/DefaultArguments.cs
@@ -160,13 +160,14 @@ namespace GeUtilities.Tests.TRefSeqParser
         [InlineData(1, 0)]
         [InlineData(2, 0)]
         [InlineData(2, 2)]
-        public void AvoidHeader(int headerCount, byte startOffset)
+        public void AvoidHeader(int headerCount, byte readOffset)
         {
             // Arrange
             using (TempFileCreator testFile = new TempFileCreator(new Columns(), headerLineCount: headerCount))
             {
                 // Act
-                RefSeqParser<Gene> parser = new RefSeqParser<Gene>(testFile.TempFilePath, startOffset: startOffset);
+                RefSeqParser<Gene> parser = new RefSeqParser<Gene>(testFile.TempFilePath);
+                parser.ReadOffset = readOffset;
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities.Tests/Stats/BEDStats.cs
+++ b/GeUtilities.Tests/Stats/BEDStats.cs
@@ -89,8 +89,9 @@ namespace GeUtilities.Tests.TStats
 
             using (TempFileCreator testFile = new TempFileCreator(peaks))
             {
-                BEDParser<ChIPSeqPeak> bedParser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, pValueFormat: PValueFormat.SameAsInput);
-                var parsedData = bedParser.Parse();
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.PValueFormat = PValueFormats.SameAsInput;
+                var parsedData = parser.Parse();
 
                 Assert.True(parsedData.Chromosomes["chr1"].Statistics.PValueHighest == 0.1);
             }
@@ -109,8 +110,9 @@ namespace GeUtilities.Tests.TStats
 
             using (TempFileCreator testFile = new TempFileCreator(peaks))
             {
-                BEDParser<ChIPSeqPeak> bedParser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, pValueFormat: PValueFormat.SameAsInput);
-                var parsedData = bedParser.Parse();
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                parser.PValueFormat = PValueFormats.SameAsInput;
+                var parsedData = parser.Parse();
 
                 Assert.True(parsedData.Statistics.PValueHighest == 0.2);
             }

--- a/GeUtilities.Tests/VCFParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/VCFParser/ConcreteClassArguments.cs
@@ -36,10 +36,7 @@ namespace GeUtilities.Tests.TVCFParser
                 // Act
                 VCFParser parser = new VCFParser(
                     testFile.TempFilePath,
-                    assembly: Assemblies.hg19,
-                    readOnlyValidChrs: true,
-                    startOffset: 0,
-                    maxLinesToRead: 1);
+                    assembly: Assemblies.hg19);
                 var parsedVariant = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert
@@ -66,10 +63,7 @@ namespace GeUtilities.Tests.TVCFParser
                     filterColumn: columns.FilterColumn,
                     infoColumn: columns.InfoColumn,
                     strandColumn: columns.StrandColumn,
-                    assembly: Assemblies.hg19,
-                    startOffset: 0,
-                    readOnlyValidChrs: true,
-                    maxLinesToRead: 1);
+                    assembly: Assemblies.hg19);
                 var parsedVariant = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/VCFParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/VCFParser/ConcreteClassArguments.cs
@@ -27,24 +27,6 @@ namespace GeUtilities.Tests.TVCFParser
         }
 
         [Fact]
-        public void PartiallySetArguments()
-        {
-            // Arrange
-            var columns = new Columns();
-            using (TempFileCreator testFile = new TempFileCreator(columns))
-            {
-                // Act
-                VCFParser parser = new VCFParser(
-                    testFile.TempFilePath,
-                    assembly: Assemblies.hg19);
-                var parsedVariant = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
-
-                // Assert
-                Assert.True(parsedVariant.CompareTo(columns.Variant) == 0);
-            }
-        }
-
-        [Fact]
         public void FullySetArguments()
         {
             // Arrange
@@ -62,8 +44,7 @@ namespace GeUtilities.Tests.TVCFParser
                     qualityColumn: columns.QualityColumn,
                     filterColumn: columns.FilterColumn,
                     infoColumn: columns.InfoColumn,
-                    strandColumn: columns.StrandColumn,
-                    assembly: Assemblies.hg19);
+                    strandColumn: columns.StrandColumn);
                 var parsedVariant = parser.Parse().Chromosomes[columns.Chr].Strands[columns.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/VCFParser/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/VCFParser/ConcreteClassArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.Parsers;
-using Genometric.GeUtilities.ReferenceGenomes;
 using Xunit;
 
 namespace GeUtilities.Tests.TVCFParser

--- a/GeUtilities.Tests/VCFParser/DefaultArguments.cs
+++ b/GeUtilities.Tests/VCFParser/DefaultArguments.cs
@@ -32,13 +32,14 @@ namespace GeUtilities.Tests.TVCFParser
         [InlineData(1, 0)]
         [InlineData(2, 0)]
         [InlineData(2, 2)]
-        public void AvoidHeader(int headerCount, byte startOffset)
+        public void AvoidHeader(int headerCount, byte readOffset)
         {
             // Arrange
             using (TempFileCreator testFile = new TempFileCreator(new Columns(), headerLineCount: headerCount))
             {
                 // Act
-                VCFParser<Variant> parser = new VCFParser<Variant>(testFile.TempFilePath, startOffset: startOffset);
+                VCFParser<Variant> parser = new VCFParser<Variant>(testFile.TempFilePath);
+                parser.ReadOffset = readOffset;
                 var parsedData = parser.Parse();
 
                 // Assert

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
@@ -11,7 +11,6 @@ namespace Genometric.GeUtilities.Parsers
     {
         public BEDParser(
             string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
@@ -24,7 +23,6 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: 4,
                 strandColumn: -1,
                 summitColumn: -1,
-                assembly: assembly,
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue)
@@ -39,7 +37,6 @@ namespace Genometric.GeUtilities.Parsers
             byte valueColumn,
             sbyte strandColumn = -1,
             sbyte summitColumn = -1,
-            Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
@@ -52,7 +49,6 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: valueColumn,
                 strandColumn: strandColumn,
                 summitColumn: summitColumn,
-                assembly: assembly,
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue)

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
@@ -14,8 +14,7 @@ namespace Genometric.GeUtilities.Parsers
             Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
-            bool dropPeakIfInvalidValue = true,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            bool dropPeakIfInvalidValue = true) :
             this(
                 sourceFilePath: sourceFilePath,
                 chrColumn: 0,
@@ -28,8 +27,7 @@ namespace Genometric.GeUtilities.Parsers
                 assembly: assembly,
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
-                dropPeakIfInvalidValue: dropPeakIfInvalidValue,
-                hashFunction: hashFunction)
+                dropPeakIfInvalidValue: dropPeakIfInvalidValue)
         { }
 
         public BEDParser(
@@ -44,8 +42,7 @@ namespace Genometric.GeUtilities.Parsers
             Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
-            bool dropPeakIfInvalidValue = true,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            bool dropPeakIfInvalidValue = true) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -58,8 +55,7 @@ namespace Genometric.GeUtilities.Parsers
                 assembly: assembly,
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
-                dropPeakIfInvalidValue: dropPeakIfInvalidValue,
-                hashFunction: hashFunction)
+                dropPeakIfInvalidValue: dropPeakIfInvalidValue)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
@@ -10,7 +10,6 @@ namespace Genometric.GeUtilities.Parsers
     {
         public BEDParser(
             string sourceFilePath,
-            PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
             this(
                 sourceFilePath: sourceFilePath,
@@ -20,8 +19,7 @@ namespace Genometric.GeUtilities.Parsers
                 nameColumn: 3,
                 valueColumn: 4,
                 strandColumn: -1,
-                summitColumn: -1,
-                pValueFormat: pValueFormat)
+                summitColumn: -1)
         { }
 
         public BEDParser(
@@ -32,8 +30,7 @@ namespace Genometric.GeUtilities.Parsers
             byte nameColumn,
             byte valueColumn,
             sbyte strandColumn = -1,
-            sbyte summitColumn = -1,
-            PValueFormat pValueFormat = PValueFormat.SameAsInput) :
+            sbyte summitColumn = -1) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -42,8 +39,7 @@ namespace Genometric.GeUtilities.Parsers
                 nameColumn: nameColumn,
                 valueColumn: valueColumn,
                 strandColumn: strandColumn,
-                summitColumn: summitColumn,
-                pValueFormat: pValueFormat)
+                summitColumn: summitColumn)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
@@ -21,8 +21,7 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: 4,
                 strandColumn: -1,
                 summitColumn: -1,
-                pValueFormat: pValueFormat,
-                dropPeakIfInvalidValue: dropPeakIfInvalidValue)
+                pValueFormat: pValueFormat)
         { }
 
         public BEDParser(
@@ -34,8 +33,7 @@ namespace Genometric.GeUtilities.Parsers
             byte valueColumn,
             sbyte strandColumn = -1,
             sbyte summitColumn = -1,
-            PValueFormat pValueFormat = PValueFormat.SameAsInput,
-            bool dropPeakIfInvalidValue = true) :
+            PValueFormat pValueFormat = PValueFormat.SameAsInput) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -45,8 +43,7 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: valueColumn,
                 strandColumn: strandColumn,
                 summitColumn: summitColumn,
-                pValueFormat: pValueFormat,
-                dropPeakIfInvalidValue: dropPeakIfInvalidValue)
+                pValueFormat: pValueFormat)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
@@ -15,9 +15,6 @@ namespace Genometric.GeUtilities.Parsers
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             this(
                 sourceFilePath: sourceFilePath,
@@ -32,9 +29,6 @@ namespace Genometric.GeUtilities.Parsers
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue,
-                startOffset: startOffset,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction)
         { }
 
@@ -51,9 +45,6 @@ namespace Genometric.GeUtilities.Parsers
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             base(
                 sourceFilePath: sourceFilePath,
@@ -68,9 +59,6 @@ namespace Genometric.GeUtilities.Parsers
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue,
-                startOffset: startOffset,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction)
         { }
     }

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParser.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IntervalBasedDataParsers.Model.Defaults;
-using Genometric.GeUtilities.ReferenceGenomes;
 
 namespace Genometric.GeUtilities.Parsers
 {
@@ -11,7 +10,6 @@ namespace Genometric.GeUtilities.Parsers
     {
         public BEDParser(
             string sourceFilePath,
-            double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
             this(
@@ -23,7 +21,6 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: 4,
                 strandColumn: -1,
                 summitColumn: -1,
-                defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue)
         { }
@@ -37,7 +34,6 @@ namespace Genometric.GeUtilities.Parsers
             byte valueColumn,
             sbyte strandColumn = -1,
             sbyte summitColumn = -1,
-            double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
             base(
@@ -49,7 +45,6 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: valueColumn,
                 strandColumn: strandColumn,
                 summitColumn: summitColumn,
-                defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue)
         { }

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
@@ -29,12 +29,6 @@ namespace Genometric.GeUtilities.Parsers
         private sbyte _summitColumn;
 
         /// <summary>
-        /// Sets and gets the default p-value that Will be used as region's p-value if the 
-        /// region in source file has an invalid p-value and 'drop_Peak_if_no_p_Value_is_given = false'
-        /// </summary>
-        private double _defaultValue;
-
-        /// <summary>
         /// Sets and gets the p-value conversion will be based on this parameter.
         /// </summary>
         private PValueFormat _pValueFormat;
@@ -69,13 +63,23 @@ namespace Genometric.GeUtilities.Parsers
         #endregion
 
         /// <summary>
+        /// Sets and gets the default p-value that Will be used as region's p-value if the 
+        /// region in source file has an invalid p-value and 'DropPeakIfNoPValueIsGiven = false'.
+        /// </summary>
+        public double DefaultValue
+        {
+            set { _defaultValue = value; }
+            get { return _defaultValue; }
+        }
+        private double _defaultValue = 1E-8;
+
+
+        /// <summary>
         /// Parse standard Browser Extensible Data (BED) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
         public BEDParser(
             string sourceFilePath,
-            double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
             this(
@@ -87,7 +91,6 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: 4,
                 strandColumn: -1,
                 summitColumn: -1,
-                defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue)
         { }
@@ -103,8 +106,6 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="valueColumn">The column number of peak value.</param>
         /// <param name="summitColumn">The column number of peak summit. If summit is not available, set this value to -1 so that the summit will the mid point of the interval.</param>
         /// <param name="strandColumn">The column number of peak strand. If input is not stranded this value should be set to -1.</param>
-        /// <param name="defaultValue">Default value of a peak. It will be used in case 
-        /// invalid value is read from source.</param>
         /// <param name="pValueFormat">It specifies the value conversion option:
         /// <para>0 : no conversion.</para>
         /// <para>1 : value = (-10)Log10(value)</para>
@@ -120,7 +121,6 @@ namespace Genometric.GeUtilities.Parsers
             byte valueColumn,
             sbyte strandColumn = -1,
             sbyte summitColumn = -1,
-            double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
             base(
@@ -134,7 +134,6 @@ namespace Genometric.GeUtilities.Parsers
             _nameColumn = nameColumn;
             _valueColumn = valueColumn;
             _summitColumn = summitColumn;
-            _defaultValue = defaultValue;
             _pValueFormat = pValueFormat;
             _dropPeakIfInvalidValue = dropPeakIfInvalidValue;
             _mostStringentPeak = new I();
@@ -165,7 +164,7 @@ namespace Genometric.GeUtilities.Parsers
                 }
                 else
                 {
-                    rtv.Value = _defaultValue;
+                    rtv.Value = DefaultValue;
                     _defaultValueUtilizationCount++;
                 }
 
@@ -188,7 +187,7 @@ namespace Genometric.GeUtilities.Parsers
                 }
                 else
                 {
-                    rtv.Value = _defaultValue;
+                    rtv.Value = DefaultValue;
                     _defaultValueUtilizationCount++;
                 }
             }

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IGenomics;
-using Genometric.GeUtilities.ReferenceGenomes;
 using System;
 
 namespace Genometric.GeUtilities.Parsers

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
@@ -79,8 +79,7 @@ namespace Genometric.GeUtilities.Parsers
             Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
-            bool dropPeakIfInvalidValue = true,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            bool dropPeakIfInvalidValue = true) :
             this(
                 sourceFilePath: sourceFilePath,
                 chrColumn: 0,
@@ -93,8 +92,7 @@ namespace Genometric.GeUtilities.Parsers
                 assembly: assembly,
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
-                dropPeakIfInvalidValue: dropPeakIfInvalidValue,
-                hashFunction: hashFunction)
+                dropPeakIfInvalidValue: dropPeakIfInvalidValue)
         { }
 
         /// <summary>
@@ -130,15 +128,13 @@ namespace Genometric.GeUtilities.Parsers
             Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
-            bool dropPeakIfInvalidValue = true,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            bool dropPeakIfInvalidValue = true) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,
                 strandColumn: strandColumn,
-                hashFunction: hashFunction,
                 data: new BED<I>(),
                 assembly: assembly)
         {

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
@@ -74,16 +74,12 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="sourceFilePath">Full path of source file name.</param>
         /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
         /// <param name="assembly"></param>
-        /// <param name="readOnlyValidChrs"></param>
         public BEDParser(
             string sourceFilePath,
             Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             this(
                 sourceFilePath: sourceFilePath,
@@ -98,9 +94,6 @@ namespace Genometric.GeUtilities.Parsers
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue,
-                startOffset: startOffset,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction)
         { }
 
@@ -110,10 +103,6 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="sourceFilePath">Full path of source file name.</param>
         /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
         /// <param name="assembly"></param>
-        /// <param name="readOnlyValidChrs"></param>
-        /// <param name="startOffset">If the source file comes with header, the number of headers lines needs to be specified so that
-        /// parser can ignore them. If not specified and header is present, header might be dropped because
-        /// of improper format it might have. </param>
         /// <param name="chrColumn">The column number of chromosome name.</param>
         /// <param name="leftEndColumn">The column number of peak left-end position.</param>
         /// <param name="rightEndColumn">The column number of peak right-end position.</param>
@@ -142,19 +131,13 @@ namespace Genometric.GeUtilities.Parsers
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             base(
                 sourceFilePath: sourceFilePath,
-                startOffset: startOffset,
                 chrColumn: chrColumn,
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,
                 strandColumn: strandColumn,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction,
                 data: new BED<I>(),
                 assembly: assembly)

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
@@ -73,10 +73,8 @@ namespace Genometric.GeUtilities.Parsers
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
         /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
-        /// <param name="assembly"></param>
         public BEDParser(
             string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
@@ -89,7 +87,6 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: 4,
                 strandColumn: -1,
                 summitColumn: -1,
-                assembly: assembly,
                 defaultValue: defaultValue,
                 pValueFormat: pValueFormat,
                 dropPeakIfInvalidValue: dropPeakIfInvalidValue)
@@ -99,8 +96,6 @@ namespace Genometric.GeUtilities.Parsers
         /// Parse standard Browser Extensible Data (BED) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
-        /// <param name="assembly"></param>
         /// <param name="chrColumn">The column number of chromosome name.</param>
         /// <param name="leftEndColumn">The column number of peak left-end position.</param>
         /// <param name="rightEndColumn">The column number of peak right-end position.</param>
@@ -125,7 +120,6 @@ namespace Genometric.GeUtilities.Parsers
             byte valueColumn,
             sbyte strandColumn = -1,
             sbyte summitColumn = -1,
-            Assemblies assembly = Assemblies.Unknown,
             double defaultValue = 1E-8,
             PValueFormat pValueFormat = PValueFormat.SameAsInput,
             bool dropPeakIfInvalidValue = true) :
@@ -135,8 +129,7 @@ namespace Genometric.GeUtilities.Parsers
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,
                 strandColumn: strandColumn,
-                data: new BED<I>(),
-                assembly: assembly)
+                data: new BED<I>())
         {
             _nameColumn = nameColumn;
             _valueColumn = valueColumn;

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
@@ -29,11 +29,6 @@ namespace Genometric.GeUtilities.Parsers
         private sbyte _summitColumn;
 
         /// <summary>
-        /// Sets and gets the p-value conversion will be based on this parameter.
-        /// </summary>
-        private PValueFormat _pValueFormat;
-
-        /// <summary>
         /// When read process is finished, this variable contains the number
         /// of regions that contained invalid p-value and replaced by default p-value. 
         /// </summary>
@@ -80,14 +75,23 @@ namespace Genometric.GeUtilities.Parsers
         }
         private bool _dropPeakIfInvalidValue = true;
 
+        /// <summary>
+        /// Sets and gets the p-value conversion.
+        /// </summary>
+        public PValueFormats PValueFormat
+        {
+            set { _pValueFormat = value; }
+            get { return _pValueFormat; }
+        }
+        private PValueFormats _pValueFormat = PValueFormats.SameAsInput;
+
 
         /// <summary>
         /// Parse standard Browser Extensible Data (BED) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
         public BEDParser(
-            string sourceFilePath,
-            PValueFormat pValueFormat = PValueFormat.SameAsInput) :
+            string sourceFilePath) :
             this(
                 sourceFilePath: sourceFilePath,
                 chrColumn: 0,
@@ -96,8 +100,7 @@ namespace Genometric.GeUtilities.Parsers
                 nameColumn: 3,
                 valueColumn: 4,
                 strandColumn: -1,
-                summitColumn: -1,
-                pValueFormat: pValueFormat)
+                summitColumn: -1)
         { }
 
         /// <summary>
@@ -111,10 +114,6 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="valueColumn">The column number of peak value.</param>
         /// <param name="summitColumn">The column number of peak summit. If summit is not available, set this value to -1 so that the summit will the mid point of the interval.</param>
         /// <param name="strandColumn">The column number of peak strand. If input is not stranded this value should be set to -1.</param>
-        /// <param name="pValueFormat">It specifies the value conversion option:
-        /// <para>0 : no conversion.</para>
-        /// <para>1 : value = (-10)Log10(value)</para>
-        /// <para>2 : value =  (-1)Log10(value)</para>
         public BEDParser(
             string sourceFilePath,
             byte chrColumn,
@@ -123,8 +122,7 @@ namespace Genometric.GeUtilities.Parsers
             byte nameColumn,
             byte valueColumn,
             sbyte strandColumn = -1,
-            sbyte summitColumn = -1,
-            PValueFormat pValueFormat = PValueFormat.SameAsInput) :
+            sbyte summitColumn = -1) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -136,7 +134,6 @@ namespace Genometric.GeUtilities.Parsers
             _nameColumn = nameColumn;
             _valueColumn = valueColumn;
             _summitColumn = summitColumn;
-            _pValueFormat = pValueFormat;
             _mostStringentPeak = new I();
             _mostPermissivePeak = new I();
             _mostStringentPeak.Value = 1;
@@ -236,12 +233,12 @@ namespace Genometric.GeUtilities.Parsers
         /// <returns>The converted p-value if the conversion type is valid, otherwise it returns 0</returns>
         private double PValueConvertor(double value)
         {
-            switch (_pValueFormat)
+            switch (PValueFormat)
             {
-                case PValueFormat.minus1_Log10_pValue: return Math.Pow(10.0, value / (-1.0));
-                case PValueFormat.minus10_Log10_pValue: return Math.Pow(10.0, value / (-10.0));
-                case PValueFormat.minus100_Log10_pValue: return Math.Pow(10.0, value / (-100.0));
-                case PValueFormat.SameAsInput:
+                case PValueFormats.minus1_Log10_pValue: return Math.Pow(10.0, value / (-1.0));
+                case PValueFormats.minus10_Log10_pValue: return Math.Pow(10.0, value / (-10.0));
+                case PValueFormats.minus100_Log10_pValue: return Math.Pow(10.0, value / (-100.0));
+                case PValueFormats.SameAsInput:
                 default: return value;
             }
         }

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/BEDParserGeneric.cs
@@ -34,11 +34,6 @@ namespace Genometric.GeUtilities.Parsers
         private PValueFormat _pValueFormat;
 
         /// <summary>
-        /// If set to true, any peak that has invalid p-value will be dropped. 
-        /// </summary>
-        private bool _dropPeakIfInvalidValue;
-
-        /// <summary>
         /// When read process is finished, this variable contains the number
         /// of regions that contained invalid p-value and replaced by default p-value. 
         /// </summary>
@@ -73,6 +68,18 @@ namespace Genometric.GeUtilities.Parsers
         }
         private double _defaultValue = 1E-8;
 
+        /// <summary>
+        /// Sets and gets if a region with invalid p-value should be 
+        /// read (using default p-value) or dropped. Therefore, if set
+        /// to true, any peak that has invalid p-value will be dropped. 
+        /// </summary>
+        public bool DropPeakIfInvalidValue
+        {
+            set { _dropPeakIfInvalidValue = value; }
+            get { return _dropPeakIfInvalidValue; }
+        }
+        private bool _dropPeakIfInvalidValue = true;
+
 
         /// <summary>
         /// Parse standard Browser Extensible Data (BED) format.
@@ -80,8 +87,7 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="sourceFilePath">Full path of source file name.</param>
         public BEDParser(
             string sourceFilePath,
-            PValueFormat pValueFormat = PValueFormat.SameAsInput,
-            bool dropPeakIfInvalidValue = true) :
+            PValueFormat pValueFormat = PValueFormat.SameAsInput) :
             this(
                 sourceFilePath: sourceFilePath,
                 chrColumn: 0,
@@ -91,8 +97,7 @@ namespace Genometric.GeUtilities.Parsers
                 valueColumn: 4,
                 strandColumn: -1,
                 summitColumn: -1,
-                pValueFormat: pValueFormat,
-                dropPeakIfInvalidValue: dropPeakIfInvalidValue)
+                pValueFormat: pValueFormat)
         { }
 
         /// <summary>
@@ -110,8 +115,6 @@ namespace Genometric.GeUtilities.Parsers
         /// <para>0 : no conversion.</para>
         /// <para>1 : value = (-10)Log10(value)</para>
         /// <para>2 : value =  (-1)Log10(value)</para>
-        /// <param name="dropPeakIfInvalidValue">If set to true, a peak with invalid value will be dropped. 
-        /// If set to false, a peak with invalid value with take up the default value.</param>
         public BEDParser(
             string sourceFilePath,
             byte chrColumn,
@@ -121,8 +124,7 @@ namespace Genometric.GeUtilities.Parsers
             byte valueColumn,
             sbyte strandColumn = -1,
             sbyte summitColumn = -1,
-            PValueFormat pValueFormat = PValueFormat.SameAsInput,
-            bool dropPeakIfInvalidValue = true) :
+            PValueFormat pValueFormat = PValueFormat.SameAsInput) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -135,7 +137,6 @@ namespace Genometric.GeUtilities.Parsers
             _valueColumn = valueColumn;
             _summitColumn = summitColumn;
             _pValueFormat = pValueFormat;
-            _dropPeakIfInvalidValue = dropPeakIfInvalidValue;
             _mostStringentPeak = new I();
             _mostPermissivePeak = new I();
             _mostStringentPeak.Value = 1;
@@ -158,7 +159,7 @@ namespace Genometric.GeUtilities.Parsers
                 {
                     rtv.Value = PValueConvertor(pValue);
                 }
-                else if (_dropPeakIfInvalidValue == true)
+                else if (DropPeakIfInvalidValue == true)
                 {
                     DropLine("\tLine " + lineCounter.ToString() + "\t:\tInvalid p-value ( " + line[_valueColumn] + " )");
                 }
@@ -181,7 +182,7 @@ namespace Genometric.GeUtilities.Parsers
             }
             else
             {
-                if (_dropPeakIfInvalidValue == true)
+                if (DropPeakIfInvalidValue == true)
                 {
                     DropLine("\tLine " + lineCounter.ToString() + "\t:\tInvalid p-value column number");
                 }

--- a/GeUtilities/IntervalBasedDataParsers/BEDParser/Enums.cs
+++ b/GeUtilities/IntervalBasedDataParsers/BEDParser/Enums.cs
@@ -4,5 +4,5 @@
 
 namespace Genometric.GeUtilities.Parsers
 {
-    public enum PValueFormat {SameAsInput, minus1_Log10_pValue, minus10_Log10_pValue, minus100_Log10_pValue };
+    public enum PValueFormats {SameAsInput, minus1_Log10_pValue, minus10_Log10_pValue, minus100_Log10_pValue };
 }

--- a/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParser.cs
@@ -10,10 +10,8 @@ namespace Genometric.GeUtilities.Parsers
     public class GTFParser : GTFParser<GeneralFeature>
     {
         public GTFParser(
-           string sourceFilePath,
-           Assemblies assembly = Assemblies.Unknown) :
+           string sourceFilePath) :
            this(sourceFilePath: sourceFilePath,
-               assembly: assembly,
                chrColumn: 0,
                sourceColumn: 1,
                featureColumn: 2,
@@ -35,8 +33,7 @@ namespace Genometric.GeUtilities.Parsers
            sbyte scoreColumn,
            sbyte strandColumn,
            sbyte frameColumn,
-           sbyte attributeColumn,
-           Assemblies assembly = Assemblies.Unknown) :
+           sbyte attributeColumn) :
            base(
                sourceFilePath: sourceFilePath,
                chrColumn: chrColumn,
@@ -47,8 +44,7 @@ namespace Genometric.GeUtilities.Parsers
                scoreColumn: scoreColumn,
                strandColumn: strandColumn,
                frameColumn: frameColumn,
-               attributeColumn: attributeColumn,
-               assembly: assembly)
+               attributeColumn: attributeColumn)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParser.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IntervalBasedDataParsers.Model.Defaults;
-using Genometric.GeUtilities.ReferenceGenomes;
 
 namespace Genometric.GeUtilities.Parsers
 {

--- a/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParser.cs
@@ -11,8 +11,7 @@ namespace Genometric.GeUtilities.Parsers
     {
         public GTFParser(
            string sourceFilePath,
-           Assemblies assembly = Assemblies.Unknown,
-           HashFunction hashFunction = HashFunction.One_at_a_Time) :
+           Assemblies assembly = Assemblies.Unknown) :
            this(sourceFilePath: sourceFilePath,
                assembly: assembly,
                chrColumn: 0,
@@ -23,8 +22,7 @@ namespace Genometric.GeUtilities.Parsers
                scoreColumn: 5,
                strandColumn: 6,
                frameColumn: 7,
-               attributeColumn: 8,
-               hashFunction: hashFunction)
+               attributeColumn: 8)
         { }
 
         public GTFParser(
@@ -38,8 +36,7 @@ namespace Genometric.GeUtilities.Parsers
            sbyte strandColumn,
            sbyte frameColumn,
            sbyte attributeColumn,
-           Assemblies assembly = Assemblies.Unknown,
-           HashFunction hashFunction = HashFunction.One_at_a_Time) :
+           Assemblies assembly = Assemblies.Unknown) :
            base(
                sourceFilePath: sourceFilePath,
                chrColumn: chrColumn,
@@ -51,8 +48,7 @@ namespace Genometric.GeUtilities.Parsers
                strandColumn: strandColumn,
                frameColumn: frameColumn,
                attributeColumn: attributeColumn,
-               assembly: assembly,
-               hashFunction: hashFunction)
+               assembly: assembly)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParser.cs
@@ -12,14 +12,9 @@ namespace Genometric.GeUtilities.Parsers
         public GTFParser(
            string sourceFilePath,
            Assemblies assembly = Assemblies.Unknown,
-           bool readOnlyValidChrs = true,
-           byte startOffset = 0,
-           uint maxLinesToRead = uint.MaxValue,
            HashFunction hashFunction = HashFunction.One_at_a_Time) :
            this(sourceFilePath: sourceFilePath,
                assembly: assembly,
-               readOnlyValidChrs: readOnlyValidChrs,
-               startOffset: startOffset,
                chrColumn: 0,
                sourceColumn: 1,
                featureColumn: 2,
@@ -29,7 +24,6 @@ namespace Genometric.GeUtilities.Parsers
                strandColumn: 6,
                frameColumn: 7,
                attributeColumn: 8,
-               maxLinesToRead: maxLinesToRead,
                hashFunction: hashFunction)
         { }
 
@@ -45,9 +39,6 @@ namespace Genometric.GeUtilities.Parsers
            sbyte frameColumn,
            sbyte attributeColumn,
            Assemblies assembly = Assemblies.Unknown,
-           bool readOnlyValidChrs = true,
-           byte startOffset = 0,
-           uint maxLinesToRead = uint.MaxValue,
            HashFunction hashFunction = HashFunction.One_at_a_Time) :
            base(
                sourceFilePath: sourceFilePath,
@@ -61,9 +52,6 @@ namespace Genometric.GeUtilities.Parsers
                frameColumn: frameColumn,
                attributeColumn: attributeColumn,
                assembly: assembly,
-               readOnlyValidChrs: readOnlyValidChrs,
-               maxLinesToRead: maxLinesToRead,
-               startOffset: startOffset,
                hashFunction: hashFunction)
         { }
     }

--- a/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParserGeneric.cs
@@ -31,19 +31,13 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="sourceFilePath">Full path of source file name.</param>
         /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
         /// <param name="assembly"></param>
-        /// <param name="readOnlyValidChrs"></param>
         public GTFParser(
             string sourceFilePath,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             this(
                 sourceFilePath: sourceFilePath,
                 assembly: assembly,
-                readOnlyValidChrs: readOnlyValidChrs,
-                startOffset: startOffset,
                 chrColumn: 0,
                 sourceColumn: 1,
                 featureColumn: 2,
@@ -53,7 +47,6 @@ namespace Genometric.GeUtilities.Parsers
                 strandColumn: 6,
                 frameColumn: 7,
                 attributeColumn: 8,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction)
         { }
 
@@ -64,10 +57,6 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="sourceFilePath">Full path of source file name.</param>
         /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
         /// <param name="assembly"></param>
-        /// <param name="readOnlyValidChrs"></param>
-        /// <param name="startOffset">If the source file comes with header, the number of headers lines needs to be specified so that
-        /// parser can ignore them. If not specified and header is present, header might be dropped because
-        /// of improper format it might have. </param>
         /// <param name="chrColumn">The column number of chromosome name.</param>
         /// <param name="leftEndColumn">The column number of feature start position.</param>
         /// <param name="rightEndColumn">The column number of feature stop position.</param>
@@ -85,19 +74,13 @@ namespace Genometric.GeUtilities.Parsers
             sbyte frameColumn,
             sbyte attributeColumn,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             base(sourceFilePath: sourceFilePath,
                 assembly: assembly,
-                startOffset: startOffset,
                 chrColumn: chrColumn,
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,
                 strandColumn: strandColumn,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction,
                 data: new GTF<I>())
         {

--- a/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParserGeneric.cs
@@ -25,19 +25,15 @@ namespace Genometric.GeUtilities.Parsers
         private sbyte _scoreColumn;
         private sbyte _frameColumn;
         private Dictionary<string, int> _features;
+
         /// <summary>
         /// Parse General Transfer Format (GTF) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
-        /// <param name="assembly"></param>
         public GTFParser(
-            string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunctions hashFunction = HashFunctions.One_at_a_Time) :
+            string sourceFilePath) :
             this(
                 sourceFilePath: sourceFilePath,
-                assembly: assembly,
                 chrColumn: 0,
                 sourceColumn: 1,
                 featureColumn: 2,
@@ -46,8 +42,7 @@ namespace Genometric.GeUtilities.Parsers
                 scoreColumn: 5,
                 strandColumn: 6,
                 frameColumn: 7,
-                attributeColumn: 8,
-                hashFunction: hashFunction)
+                attributeColumn: 8)
         { }
 
 
@@ -55,8 +50,6 @@ namespace Genometric.GeUtilities.Parsers
         /// Parse General Transfer Format (GTF) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
-        /// <param name="assembly"></param>
         /// <param name="chrColumn">The column number of chromosome name.</param>
         /// <param name="leftEndColumn">The column number of feature start position.</param>
         /// <param name="rightEndColumn">The column number of feature stop position.</param>
@@ -72,11 +65,8 @@ namespace Genometric.GeUtilities.Parsers
             sbyte scoreColumn,
             sbyte strandColumn,
             sbyte frameColumn,
-            sbyte attributeColumn,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunctions hashFunction = HashFunctions.One_at_a_Time) :
+            sbyte attributeColumn) :
             base(sourceFilePath: sourceFilePath,
-                assembly: assembly,
                 chrColumn: chrColumn,
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,

--- a/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParserGeneric.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IGenomics;
-using Genometric.GeUtilities.ReferenceGenomes;
 using System.Collections.Generic;
 
 namespace Genometric.GeUtilities.Parsers

--- a/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/GTFParser/GTFParserGeneric.cs
@@ -34,7 +34,7 @@ namespace Genometric.GeUtilities.Parsers
         public GTFParser(
             string sourceFilePath,
             Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            HashFunctions hashFunction = HashFunctions.One_at_a_Time) :
             this(
                 sourceFilePath: sourceFilePath,
                 assembly: assembly,
@@ -74,14 +74,13 @@ namespace Genometric.GeUtilities.Parsers
             sbyte frameColumn,
             sbyte attributeColumn,
             Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            HashFunctions hashFunction = HashFunctions.One_at_a_Time) :
             base(sourceFilePath: sourceFilePath,
                 assembly: assembly,
                 chrColumn: chrColumn,
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,
                 strandColumn: strandColumn,
-                hashFunction: hashFunction,
                 data: new GTF<I>())
         {
             _sourceColumn = sourceColumn;

--- a/GeUtilities/IntervalBasedDataParsers/Model/Enums.cs
+++ b/GeUtilities/IntervalBasedDataParsers/Model/Enums.cs
@@ -4,7 +4,7 @@
 
 namespace Genometric.GeUtilities.Parsers
 {
-    public enum HashFunction
+    public enum HashFunctions
     {
         /// <summary>
         /// Calculates a hash key based on One-at-a-Time method

--- a/GeUtilities/IntervalBasedDataParsers/Parser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/Parser.cs
@@ -17,7 +17,6 @@ namespace Genometric.GeUtilities.Parsers
         where S : IStats<int>, new()
     {
         private ParsedIntervals<I, S> _data;
-        private HashFunction _hashFunction;
 
         private const UInt32 _FNVPrime_32 = 16777619;
         private const UInt32 _FNVOffsetBasis_32 = 2166136261;
@@ -133,13 +132,18 @@ namespace Genometric.GeUtilities.Parsers
         public ReadOnlyCollection<string> MissingChrs { get { return _missingChrs.AsReadOnly(); } }
         private List<string> _missingChrs;
 
+        /// <summary>
+        /// Sets and gets the hash function used to create hash 
+        /// value of each parsed interval. 
+        /// </summary>
+        public HashFunctions HashFunction { set; get; }
+
         public Parser(
             string sourceFilePath,
             byte chrColumn,
             byte leftEndColumn,
             sbyte rightEndColumn,
             sbyte strandColumn,
-            HashFunction hashFunction,
             ParsedIntervals<I, S> data,
             Assemblies assembly = Assemblies.Unknown)
         {
@@ -149,7 +153,6 @@ namespace Genometric.GeUtilities.Parsers
             _leftColumn = leftEndColumn;
             _rightColumn = rightEndColumn;
             _strandColumn = strandColumn;
-            _hashFunction = hashFunction;
             _data = data;
             _data.FilePath = Path.GetFullPath(_sourceFilePath);
             _data.FileName = Path.GetFileName(_sourceFilePath);
@@ -244,14 +247,14 @@ namespace Genometric.GeUtilities.Parsers
                                 if (strand != '+' && strand != '-' && strand != '*')
                                     strand = '*';
 
-                        switch (_hashFunction)
+                        switch (HashFunction)
                         {
-                            case HashFunction.One_at_a_Time:
+                            case HashFunctions.One_at_a_Time:
                             default:
                                 readingInterval.HashKey = OneAtATimeHashFunction(readingInterval, lineCounter);
                                 break;
 
-                            case HashFunction.FNV:
+                            case HashFunctions.FNV:
                                 readingInterval.HashKey = FNVHashFunction(readingInterval, lineCounter);
                                 break;
                         }

--- a/GeUtilities/IntervalBasedDataParsers/Parser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/Parser.cs
@@ -27,11 +27,6 @@ namespace Genometric.GeUtilities.Parsers
         private string _sourceFilePath;
 
         /// <summary>
-        /// 
-        /// </summary>
-        private Assemblies _assembly;
-
-        /// <summary>
         /// Sets and gets the column number of chromosome name.
         /// </summary>
         private byte _chrColumn;
@@ -122,7 +117,7 @@ namespace Genometric.GeUtilities.Parsers
         public bool ReadOnlyAssemblyChrs
         {
             set { _readOnlyAssemblyChrs = value; }
-            get { return _assembly == Assemblies.Unknown ? false : _readOnlyAssemblyChrs; }
+            get { return Assembly == Assemblies.Unknown ? false : _readOnlyAssemblyChrs; }
         }
         private bool _readOnlyAssemblyChrs = true;
 
@@ -138,17 +133,23 @@ namespace Genometric.GeUtilities.Parsers
         /// </summary>
         public HashFunctions HashFunction { set; get; }
 
+        /// <summary>
+        /// Set and gets the assembly of source file. 
+        /// The assembly info are used for variety of purposes,
+        /// e.g., to determine if a region has a 
+        /// chromosome value valid w.r.t. to the assembly.
+        /// </summary>
+        public Assemblies Assembly { set; get; }
+
         public Parser(
             string sourceFilePath,
             byte chrColumn,
             byte leftEndColumn,
             sbyte rightEndColumn,
             sbyte strandColumn,
-            ParsedIntervals<I, S> data,
-            Assemblies assembly = Assemblies.Unknown)
+            ParsedIntervals<I, S> data)
         {
             _sourceFilePath = sourceFilePath;
-            _assembly = assembly;
             _chrColumn = chrColumn;
             _leftColumn = leftEndColumn;
             _rightColumn = rightEndColumn;
@@ -157,8 +158,6 @@ namespace Genometric.GeUtilities.Parsers
             _data.FilePath = Path.GetFullPath(_sourceFilePath);
             _data.FileName = Path.GetFileName(_sourceFilePath);
             _data.FileHashKey = GetFileHashKey(_data.FilePath);
-            _data.Assembly = _assembly;
-            _assemblyData = References.GetGenomeSizes(_assembly);
             _excessChrs = new List<string>();
             _missingChrs = new List<string>();
         }
@@ -169,6 +168,7 @@ namespace Genometric.GeUtilities.Parsers
         /// <returns>Returns parsed intervals.</returns>
         protected ParsedIntervals<I, S> Parse()
         {
+            _assemblyData = References.GetGenomeSizes(Assembly);
             if (!File.Exists(_sourceFilePath))
                 throw new FileNotFoundException(string.Format("The file `{0}` does not exist or is inaccessible.", _sourceFilePath));
 
@@ -269,9 +269,10 @@ namespace Genometric.GeUtilities.Parsers
                 Messages.Insert(0, "\t" + _dropedLinesCount.ToString() + " Lines dropped");
             _data.Messages = Messages;
 
-            if (_assembly != Assemblies.Unknown)
+            if (Assembly != Assemblies.Unknown)
                 ReadMissingAndExcessChrs();
 
+            _data.Assembly = Assembly;
             return _data;
         }
 

--- a/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParser.cs
@@ -11,8 +11,7 @@ namespace Genometric.GeUtilities.Parsers
     {
         public RefSeqParser(
             string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            Assemblies assembly = Assemblies.Unknown) :
             this(sourceFilePath: sourceFilePath,
                 assembly: assembly,
                 chrColumn: 0,
@@ -20,9 +19,7 @@ namespace Genometric.GeUtilities.Parsers
                 rightEndColumn: 2,
                 refSeqIDColumn: 3,
                 geneSymbolColumn: 4,
-                strandColumn: -1,
-                hashFunction: hashFunction
-                )
+                strandColumn: -1)
         { }
 
         public RefSeqParser(
@@ -33,8 +30,7 @@ namespace Genometric.GeUtilities.Parsers
             byte refSeqIDColumn,
             byte geneSymbolColumn,
             sbyte strandColumn = -1,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            Assemblies assembly = Assemblies.Unknown) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -43,8 +39,7 @@ namespace Genometric.GeUtilities.Parsers
                 refSeqIDColumn: refSeqIDColumn,
                 geneSymbolColumn: geneSymbolColumn,
                 strandColumn: strandColumn,
-                assembly: assembly,
-                hashFunction: hashFunction)
+                assembly: assembly)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParser.cs
@@ -12,21 +12,15 @@ namespace Genometric.GeUtilities.Parsers
         public RefSeqParser(
             string sourceFilePath,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             this(sourceFilePath: sourceFilePath,
                 assembly: assembly,
-                readOnlyValidChrs: readOnlyValidChrs,
-                startOffset: startOffset,
                 chrColumn: 0,
                 leftEndColumn: 1,
                 rightEndColumn: 2,
                 refSeqIDColumn: 3,
                 geneSymbolColumn: 4,
                 strandColumn: -1,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction
                 )
         { }
@@ -40,9 +34,6 @@ namespace Genometric.GeUtilities.Parsers
             byte geneSymbolColumn,
             sbyte strandColumn = -1,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             base(
                 sourceFilePath: sourceFilePath,
@@ -53,9 +44,6 @@ namespace Genometric.GeUtilities.Parsers
                 geneSymbolColumn: geneSymbolColumn,
                 strandColumn: strandColumn,
                 assembly: assembly,
-                startOffset: startOffset,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction)
         { }
     }

--- a/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParser.cs
@@ -3,17 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IntervalBasedDataParsers.Model.Defaults;
-using Genometric.GeUtilities.ReferenceGenomes;
 
 namespace Genometric.GeUtilities.Parsers
 {
     public class RefSeqParser : RefSeqParser<Gene>
     {
         public RefSeqParser(
-            string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown) :
+            string sourceFilePath) :
             this(sourceFilePath: sourceFilePath,
-                assembly: assembly,
                 chrColumn: 0,
                 leftEndColumn: 1,
                 rightEndColumn: 2,
@@ -29,8 +26,7 @@ namespace Genometric.GeUtilities.Parsers
             sbyte rightEndColumn,
             byte refSeqIDColumn,
             byte geneSymbolColumn,
-            sbyte strandColumn = -1,
-            Assemblies assembly = Assemblies.Unknown) :
+            sbyte strandColumn = -1) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -38,8 +34,7 @@ namespace Genometric.GeUtilities.Parsers
                 rightEndColumn: rightEndColumn,
                 refSeqIDColumn: refSeqIDColumn,
                 geneSymbolColumn: geneSymbolColumn,
-                strandColumn: strandColumn,
-                assembly: assembly)
+                strandColumn: strandColumn)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParserGeneric.cs
@@ -30,26 +30,19 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="sourceFilePath">Full path of source file name.</param>
         /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
         /// <param name="assembly"></param>
-        /// <param name="readOnlyValidChrs"></param>
         public RefSeqParser(
             string sourceFilePath,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             this(
                 sourceFilePath: sourceFilePath,
                 assembly: assembly,
-                readOnlyValidChrs: readOnlyValidChrs,
-                startOffset: startOffset,
                 chrColumn: 0,
                 leftEndColumn: 1,
                 rightEndColumn: 2,
                 refSeqIDColumn: 3,
                 geneSymbolColumn: 4,
                 strandColumn: -1,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction
                 )
         { }
@@ -61,10 +54,6 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="sourceFilePath">Full path of source file name</param>
         /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
         /// <param name="assembly"></param>
-        /// <param name="readOnlyValidChrs"></param>
-        /// <param name="startOffset">If the source file comes with header, the number of headers lines needs to be specified so that
-        /// parser can ignore them. If not specified and header is present, header might be dropped because
-        /// of improper format it might have. </param>
         /// <param name="chrColumn">The column number of chromosome name</param>
         /// <param name="leftEndColumn">The column number of gene start position</param>
         /// <param name="rightEndColumn">The column number of gene stop position</param>
@@ -77,19 +66,13 @@ namespace Genometric.GeUtilities.Parsers
             byte geneSymbolColumn,
             sbyte strandColumn = -1,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             base(sourceFilePath: sourceFilePath,
                 assembly: assembly,
-                startOffset: startOffset,
                 chrColumn: chrColumn,
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,
                 strandColumn: strandColumn,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction,
                 data: new RefSeq<I>())
         {

--- a/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParserGeneric.cs
@@ -28,14 +28,10 @@ namespace Genometric.GeUtilities.Parsers
         /// Parse refseq genes presented in tab-delimited text file.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
-        /// <param name="assembly"></param>
         public RefSeqParser(
-            string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown) :
+            string sourceFilePath) :
             this(
                 sourceFilePath: sourceFilePath,
-                assembly: assembly,
                 chrColumn: 0,
                 leftEndColumn: 1,
                 rightEndColumn: 2,
@@ -49,8 +45,6 @@ namespace Genometric.GeUtilities.Parsers
         /// Parse refseq genes presented in tab-delimited text file.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name</param>
-        /// <param name="genome">This parameter will be used for initializing the chromosome count and sex chromosomes mappings.</param>
-        /// <param name="assembly"></param>
         /// <param name="chrColumn">The column number of chromosome name</param>
         /// <param name="leftEndColumn">The column number of gene start position</param>
         /// <param name="rightEndColumn">The column number of gene stop position</param>
@@ -61,10 +55,8 @@ namespace Genometric.GeUtilities.Parsers
             sbyte rightEndColumn,
             byte refSeqIDColumn,
             byte geneSymbolColumn,
-            sbyte strandColumn = -1,
-            Assemblies assembly = Assemblies.Unknown) :
+            sbyte strandColumn = -1) :
             base(sourceFilePath: sourceFilePath,
-                assembly: assembly,
                 chrColumn: chrColumn,
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,

--- a/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParserGeneric.cs
@@ -32,8 +32,7 @@ namespace Genometric.GeUtilities.Parsers
         /// <param name="assembly"></param>
         public RefSeqParser(
             string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            Assemblies assembly = Assemblies.Unknown) :
             this(
                 sourceFilePath: sourceFilePath,
                 assembly: assembly,
@@ -42,9 +41,7 @@ namespace Genometric.GeUtilities.Parsers
                 rightEndColumn: 2,
                 refSeqIDColumn: 3,
                 geneSymbolColumn: 4,
-                strandColumn: -1,
-                hashFunction: hashFunction
-                )
+                strandColumn: -1)
         { }
 
 
@@ -65,15 +62,13 @@ namespace Genometric.GeUtilities.Parsers
             byte refSeqIDColumn,
             byte geneSymbolColumn,
             sbyte strandColumn = -1,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            Assemblies assembly = Assemblies.Unknown) :
             base(sourceFilePath: sourceFilePath,
                 assembly: assembly,
                 chrColumn: chrColumn,
                 leftEndColumn: leftEndColumn,
                 rightEndColumn: rightEndColumn,
                 strandColumn: strandColumn,
-                hashFunction: hashFunction,
                 data: new RefSeq<I>())
         {
             _refSeqIDColumn = refSeqIDColumn;

--- a/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/RefSeqParser/RefSeqParserGeneric.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IGenomics;
-using Genometric.GeUtilities.ReferenceGenomes;
 
 namespace Genometric.GeUtilities.Parsers
 {

--- a/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParser.cs
@@ -11,8 +11,7 @@ namespace Genometric.GeUtilities.Parsers
     {
         public VCFParser(
             string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            Assemblies assembly = Assemblies.Unknown) :
             this(sourceFilePath: sourceFilePath,
                 assembly: assembly,
                 chrColumn: 0,
@@ -23,8 +22,7 @@ namespace Genometric.GeUtilities.Parsers
                 qualityColumn: 5,
                 filterColumn: 6,
                 infoColumn: 7,
-                strandColumn: -1,
-                hashFunction: hashFunction)
+                strandColumn: -1)
         { }
 
         public VCFParser(
@@ -38,8 +36,7 @@ namespace Genometric.GeUtilities.Parsers
             byte filterColumn,
             byte infoColumn,
             sbyte strandColumn,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            Assemblies assembly = Assemblies.Unknown) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -51,8 +48,7 @@ namespace Genometric.GeUtilities.Parsers
                 filterColumn: filterColumn,
                 infoColumn: infoColumn,
                 strandColumn: strandColumn,
-                assembly: assembly,
-                hashFunction: hashFunction)
+                assembly: assembly)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParser.cs
@@ -10,10 +10,8 @@ namespace Genometric.GeUtilities.Parsers
     public class VCFParser : VCFParser<Variant>
     {
         public VCFParser(
-            string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown) :
+            string sourceFilePath) :
             this(sourceFilePath: sourceFilePath,
-                assembly: assembly,
                 chrColumn: 0,
                 positionColumn: 1,
                 idColumn: 2,
@@ -35,8 +33,7 @@ namespace Genometric.GeUtilities.Parsers
             byte qualityColumn,
             byte filterColumn,
             byte infoColumn,
-            sbyte strandColumn,
-            Assemblies assembly = Assemblies.Unknown) :
+            sbyte strandColumn) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,
@@ -47,8 +44,7 @@ namespace Genometric.GeUtilities.Parsers
                 qualityColumn: qualityColumn,
                 filterColumn: filterColumn,
                 infoColumn: infoColumn,
-                strandColumn: strandColumn,
-                assembly: assembly)
+                strandColumn: strandColumn)
         { }
     }
 }

--- a/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParser.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IntervalBasedDataParsers.Model.Defaults;
-using Genometric.GeUtilities.ReferenceGenomes;
 
 namespace Genometric.GeUtilities.Parsers
 {

--- a/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParser.cs
+++ b/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParser.cs
@@ -12,9 +12,6 @@ namespace Genometric.GeUtilities.Parsers
         public VCFParser(
             string sourceFilePath,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             this(sourceFilePath: sourceFilePath,
                 assembly: assembly,
@@ -27,9 +24,6 @@ namespace Genometric.GeUtilities.Parsers
                 filterColumn: 6,
                 infoColumn: 7,
                 strandColumn: -1,
-                startOffset: startOffset,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction)
         { }
 
@@ -45,9 +39,6 @@ namespace Genometric.GeUtilities.Parsers
             byte infoColumn,
             sbyte strandColumn,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             base(
                 sourceFilePath: sourceFilePath,
@@ -61,9 +52,6 @@ namespace Genometric.GeUtilities.Parsers
                 infoColumn: infoColumn,
                 strandColumn: strandColumn,
                 assembly: assembly,
-                startOffset: startOffset,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction)
         { }
     }

--- a/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParserGeneric.cs
@@ -24,9 +24,6 @@ namespace Genometric.GeUtilities.Parsers
         public VCFParser(
             string sourceFilePath,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             this(sourceFilePath: sourceFilePath,
                 assembly: assembly,
@@ -39,9 +36,6 @@ namespace Genometric.GeUtilities.Parsers
                 filterColumn: 6,
                 infoColumn: 7,
                 strandColumn: -1,
-                startOffset: startOffset,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction)
         { }
 
@@ -57,20 +51,14 @@ namespace Genometric.GeUtilities.Parsers
             byte infoColumn,
             sbyte strandColumn,
             Assemblies assembly = Assemblies.Unknown,
-            bool readOnlyValidChrs = true,
-            byte startOffset = 0,
-            uint maxLinesToRead = uint.MaxValue,
             HashFunction hashFunction = HashFunction.One_at_a_Time) :
             base(
                 sourceFilePath: sourceFilePath,
                 assembly: assembly,
-                startOffset: startOffset,
                 chrColumn: chrColumn,
                 leftEndColumn: positionColumn,
                 rightEndColumn: -1,
                 strandColumn: strandColumn,
-                readOnlyValidChrs: readOnlyValidChrs,
-                maxLinesToRead: maxLinesToRead,
                 hashFunction: hashFunction,
                 data: new VCF<I>())
         {

--- a/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParserGeneric.cs
@@ -51,7 +51,6 @@ namespace Genometric.GeUtilities.Parsers
             Assemblies assembly = Assemblies.Unknown) :
             base(
                 sourceFilePath: sourceFilePath,
-                assembly: assembly,
                 chrColumn: chrColumn,
                 leftEndColumn: positionColumn,
                 rightEndColumn: -1,

--- a/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParserGeneric.cs
@@ -23,8 +23,7 @@ namespace Genometric.GeUtilities.Parsers
 
         public VCFParser(
             string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            Assemblies assembly = Assemblies.Unknown) :
             this(sourceFilePath: sourceFilePath,
                 assembly: assembly,
                 chrColumn: 0,
@@ -35,8 +34,7 @@ namespace Genometric.GeUtilities.Parsers
                 qualityColumn: 5,
                 filterColumn: 6,
                 infoColumn: 7,
-                strandColumn: -1,
-                hashFunction: hashFunction)
+                strandColumn: -1)
         { }
 
         public VCFParser(
@@ -50,8 +48,7 @@ namespace Genometric.GeUtilities.Parsers
             byte filterColumn,
             byte infoColumn,
             sbyte strandColumn,
-            Assemblies assembly = Assemblies.Unknown,
-            HashFunction hashFunction = HashFunction.One_at_a_Time) :
+            Assemblies assembly = Assemblies.Unknown) :
             base(
                 sourceFilePath: sourceFilePath,
                 assembly: assembly,
@@ -59,7 +56,6 @@ namespace Genometric.GeUtilities.Parsers
                 leftEndColumn: positionColumn,
                 rightEndColumn: -1,
                 strandColumn: strandColumn,
-                hashFunction: hashFunction,
                 data: new VCF<I>())
         {
             _idColumn = idColumn;

--- a/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParserGeneric.cs
+++ b/GeUtilities/IntervalBasedDataParsers/VCFParser/VCFParserGeneric.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Genometric.GeUtilities.IGenomics;
-using Genometric.GeUtilities.ReferenceGenomes;
 
 namespace Genometric.GeUtilities.Parsers
 {
@@ -22,10 +21,8 @@ namespace Genometric.GeUtilities.Parsers
         #endregion
 
         public VCFParser(
-            string sourceFilePath,
-            Assemblies assembly = Assemblies.Unknown) :
+            string sourceFilePath) :
             this(sourceFilePath: sourceFilePath,
-                assembly: assembly,
                 chrColumn: 0,
                 positionColumn: 1,
                 idColumn: 2,
@@ -47,8 +44,7 @@ namespace Genometric.GeUtilities.Parsers
             byte qualityColumn,
             byte filterColumn,
             byte infoColumn,
-            sbyte strandColumn,
-            Assemblies assembly = Assemblies.Unknown) :
+            sbyte strandColumn) :
             base(
                 sourceFilePath: sourceFilePath,
                 chrColumn: chrColumn,


### PR DESCRIPTION
Except for source file and column orders, all other arguments are removed parsers constructors and defined as properties of parsers. All the unit tests are updated accordingly. 