### PR TITLE
Update appveyor SonarQube to test PRs.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ clone_depth: 1
 
 build_script:
   - choco install "msbuild-sonarqube-runner" -y
-  - MSBuild.SonarQube.Runner.exe begin /k:"geutilities" /o:"genometric" /d:"sonar.host.url=https://sonarcloud.io"
+  - MSBuild.SonarQube.Runner.exe begin /k:"geutilities" /o:"genometric" /d:"sonar.host.url=https://sonarcloud.io" -Dsonar.analysis.mode=preview
   - MSBuild.exe /t:Rebuild
   - MSBuild.SonarQube.Runner.exe end 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ clone_depth: 1
 
 build_script:
   - choco install "msbuild-sonarqube-runner" -y
-  - MSBuild.SonarQube.Runner.exe begin /k:"geutilities" /o:"genometric" /d:"sonar.host.url=https://sonarcloud.io" -Dsonar.analysis.mode=preview
+  - MSBuild.SonarQube.Runner.exe begin /k:"geutilities" /o:"genometric" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.analysis.mode=preview"
   - MSBuild.exe /t:Rebuild
   - MSBuild.SonarQube.Runner.exe end 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,12 @@ build:
   verbosity: minimal
 clone_depth: 1
 
+build_script:
+  - choco install "msbuild-sonarqube-runner" -y
+  - MSBuild.SonarQube.Runner.exe begin /k:"geutilities" /o:"genometric" /d:"sonar.host.url=https://sonarcloud.io"
+  - MSBuild.exe /t:Rebuild
+  - MSBuild.SonarQube.Runner.exe end 
+
 test_script:
   # restore packages for our unit tests
   - cmd: dotnet restore GeUtilities.Tests\GeUtilities.Tests.csproj --verbosity m


### PR DESCRIPTION
`Sonarqube` analyzes only internal PRs, it is because uploading results to SonarCloud would require API keys and these keys should not be exposed to PRs from forks. Therefore, once a PRs is created from a fork, issues introduced in that PR are not determined by `Sonarqube` until merging dev branch to master. In order to analyze PRs even from forks, this PR users Sonar Github plugin which in addition to identifying issues, provides inline comments about introduced code smells. 