### PR TITLE
Refactoring stream writers in test file creators to ensure they are disposed only once

### DIFF
--- a/GeUtilities.Tests/BEDParser/TempFileCreator.cs
+++ b/GeUtilities.Tests/BEDParser/TempFileCreator.cs
@@ -25,7 +25,10 @@ namespace GeUtilities.Tests.TBEDParser
                 _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".bed";
                 fs = File.Create(TempFilePath);
                 using (StreamWriter sw = new StreamWriter(fs))
+                {
+                    fs = null;
                     sw.WriteLine(peak);
+                }
             }
             finally
             {
@@ -42,8 +45,11 @@ namespace GeUtilities.Tests.TBEDParser
                 _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".bed";
                 fs = File.Create(TempFilePath);
                 using (StreamWriter sw = new StreamWriter(fs))
+                {
+                    fs = null;
                     foreach (var peak in peaks)
                         sw.WriteLine(peak);
+                }
             }
             finally
             {
@@ -61,6 +67,7 @@ namespace GeUtilities.Tests.TBEDParser
                 fs = File.Create(TempFilePath);
                 using (StreamWriter sw = new StreamWriter(fs))
                 {
+                    fs = null;
                     while (headerLineCount-- > 0)
                         sw.WriteLine(columns.GetSampleHeader());
 

--- a/GeUtilities.Tests/GTFParser/TempFileCreator.cs
+++ b/GeUtilities.Tests/GTFParser/TempFileCreator.cs
@@ -20,7 +20,10 @@ namespace GeUtilities.Tests.TGTFParser
                 _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".gtf";
                 fs = File.Create(_tempFilePath);
                 using (StreamWriter sw = new StreamWriter(fs))
+                {
+                    fs = null;
                     sw.WriteLine(line);
+                }
             }
             finally
             {
@@ -38,6 +41,7 @@ namespace GeUtilities.Tests.TGTFParser
                 fs = File.Create(_tempFilePath);
                 using (StreamWriter sw = new StreamWriter(fs))
                 {
+                    fs = null;
                     while (headerLineCount-- > 0)
                         sw.WriteLine(columns.GetSampleHeader());
 

--- a/GeUtilities.Tests/RefSeqParser/TempFileCreator.cs
+++ b/GeUtilities.Tests/RefSeqParser/TempFileCreator.cs
@@ -20,7 +20,10 @@ namespace GeUtilities.Tests.TRefSeqParser
                 _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".refSeq";
                 fs = File.Create(_tempFilePath);
                 using (StreamWriter sw = new StreamWriter(fs))
+                {
+                    fs = null;
                     sw.WriteLine(line);
+                }
             }
             finally
             {
@@ -38,6 +41,7 @@ namespace GeUtilities.Tests.TRefSeqParser
                 fs = File.Create(_tempFilePath);
                 using (StreamWriter sw = new StreamWriter(fs))
                 {
+                    fs = null;
                     while (headerLineCount-- > 0)
                         sw.WriteLine(columns.GetSampleHeader());
 

--- a/GeUtilities.Tests/VCFParser/TempFileCreator.cs
+++ b/GeUtilities.Tests/VCFParser/TempFileCreator.cs
@@ -15,26 +15,48 @@ namespace GeUtilities.Tests.TVCFParser
         public TempFileCreator(string line)
         {
             _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".vcf";
-            using (FileStream fs = File.Create(_tempFilePath))
-            using (StreamWriter sw = new StreamWriter(fs))
-                sw.WriteLine(line);
+            FileStream fs = null;
+            try
+            {
+                fs = File.Create(_tempFilePath);
+                using (StreamWriter sw = new StreamWriter(fs))
+                {
+                    fs = null;
+                    sw.WriteLine(line);
+                }
+            }
+            finally
+            {
+                if (fs != null)
+                    fs.Dispose();
+            }
         }
 
         public TempFileCreator(Columns columns, int headerLineCount = 0, int variantsCount = 1)
         {
             _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".vcf";
-            using (FileStream fs = File.Create(_tempFilePath))
-            using (StreamWriter sw = new StreamWriter(fs))
+            FileStream fs = null;
+            try
             {
-                while (headerLineCount-- > 0)
-                    sw.WriteLine(columns.GetSampleHeader());
-
-                while (variantsCount-- > 0)
+                fs = File.Create(_tempFilePath);
+                using (StreamWriter sw = new StreamWriter(fs))
                 {
-                    sw.WriteLine(columns.GetSampleLine());
-                    if (variantsCount > 0)
-                        columns.Position += 10;
+                    fs = null;
+                    while (headerLineCount-- > 0)
+                        sw.WriteLine(columns.GetSampleHeader());
+
+                    while (variantsCount-- > 0)
+                    {
+                        sw.WriteLine(columns.GetSampleLine());
+                        if (variantsCount > 0)
+                            columns.Position += 10;
+                    }
                 }
+            }
+            finally
+            {
+                if (fs != null)
+                    fs.Dispose();
             }
         }
 


### PR DESCRIPTION
Two inner `using` might result in disposing stream writers twice. Hence non-compliant with `IDisposable` implementation. To avoid it, the outer `using` is refactored and the code is environed in a `try-finally` block. 