### PR TITLE
Move parsers source file specification from constructor to Parse function

### DIFF
--- a/GeUtilities.Tests/IntervalParsers/BED/ColumnsOrder.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/ColumnsOrder.cs
@@ -35,7 +35,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                 ValueColumn = valueColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(
@@ -47,7 +47,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                         Name = nameColumn,
                         Value = valueColumn
                     });
-                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedPeak = parser.Parse(file.Path).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);
@@ -69,11 +69,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                 StrandColumn = 0,
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(rg.Columns);
-                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedPeak = parser.Parse(file.Path).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);
@@ -94,11 +94,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             var rg = new RegionGenerator { SummitColumn = summitColumn };
             rg.Summit = summit == -1 ? rg.Left + ((rg.Right - rg.Left) / 2) : summit;
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(rg.Columns);
-                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedPeak = parser.Parse(file.Path).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.Summit == rg.Summit);
@@ -121,13 +121,13 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                 StrandColumn = strandColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(rg.Columns);
 
                 // Assert
-                Assert.True(parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands.ContainsKey(strand));
+                Assert.True(parser.Parse(file.Path).Chromosomes[rg.Chr].Strands.ContainsKey(strand));
             }
         }
 
@@ -143,7 +143,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                 "chr1\t50\t60\t#\tGeUtilities_02\t111.0", // Any strand name other than '+', '-', and '*' will be parsed as '*'.
             };
 
-            using (var testFile = new TempFileCreator(peaks))
+            using (var file = new TempFileCreator(peaks))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(
@@ -157,7 +157,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                         Value = 5
                     });
 
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes["chr1"].Strands.ContainsKey('*'));

--- a/GeUtilities.Tests/IntervalParsers/BED/ColumnsOrder.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/ColumnsOrder.cs
@@ -39,7 +39,6 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(
-                    testFile.TempFilePath,
                     new BEDColumns()
                     {
                         Chr = chrColumn,
@@ -48,7 +47,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                         Name = nameColumn,
                         Value = valueColumn
                     });
-                var parsedPeak = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);
@@ -73,8 +72,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, rg.Columns);
-                var parsedPeak = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new BEDParser<ChIPSeqPeak>(rg.Columns);
+                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);
@@ -98,8 +97,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, rg.Columns);
-                var parsedPeak = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new BEDParser<ChIPSeqPeak>(rg.Columns);
+                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.Summit == rg.Summit);
@@ -125,10 +124,10 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, rg.Columns);
+                var parser = new BEDParser<ChIPSeqPeak>(rg.Columns);
 
                 // Assert
-                Assert.True(parser.Parse().Chromosomes[rg.Chr].Strands.ContainsKey(strand));
+                Assert.True(parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands.ContainsKey(strand));
             }
         }
 
@@ -148,7 +147,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(
-                    testFile.TempFilePath, new BEDColumns
+                    new BEDColumns
                     {
                         Chr = 0,
                         Left = 1,
@@ -158,7 +157,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                         Value = 5
                     });
 
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes["chr1"].Strands.ContainsKey('*'));

--- a/GeUtilities.Tests/IntervalParsers/BED/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/ConcreteClassArguments.cs
@@ -20,8 +20,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser(testFile.TempFilePath);
-                var parsedPeak = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new BEDParser();
+                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);
@@ -36,8 +36,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser(testFile.TempFilePath, rg.Columns);
-                var parsedPeak = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new BEDParser(rg.Columns);
+                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);

--- a/GeUtilities.Tests/IntervalParsers/BED/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/ConcreteClassArguments.cs
@@ -17,11 +17,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser();
-                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedPeak = parser.Parse(file.Path).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);
@@ -33,11 +33,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser(rg.Columns);
-                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedPeak = parser.Parse(file.Path).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);

--- a/GeUtilities.Tests/IntervalParsers/BED/DefaultArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/DefaultArguments.cs
@@ -22,8 +22,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator())
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedPeak = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);
@@ -42,11 +42,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     ReadOffset = readOffset
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 1);
@@ -66,8 +66,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(new RegionGenerator { Chr = chr }))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey(chr));
@@ -83,8 +83,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(new RegionGenerator { Chr = "chr1" }))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey(chr));
@@ -99,8 +99,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // ACt
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands.ContainsKey(rg.Strand));
@@ -115,8 +115,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Left == rg.Left);
@@ -130,8 +130,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator("chr1\t10V\t20\tGeUtilities_01\t123.4"))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -146,8 +146,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (TempFileCreator testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Right == rg.Right);
@@ -161,8 +161,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator("chr1\t10\t20V\tGeUtilities_01\t123.4"))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -176,8 +176,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123.4"))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, new BEDColumns() { Right = 10 });
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Right = 10 });
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -192,8 +192,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Name == rg.Name);
@@ -208,8 +208,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Value == rg.Value);
@@ -223,8 +223,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -239,8 +239,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);

--- a/GeUtilities.Tests/IntervalParsers/BED/DefaultArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/DefaultArguments.cs
@@ -19,11 +19,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator())
+            using (var file = new TempFileCreator())
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedPeak = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedPeak = parser.Parse(file.Path).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedPeak.CompareTo(rg.Peak) == 0);
@@ -39,14 +39,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void AvoidHeader(int headerCount, byte readOffset)
         {
             // Arrange
-            using (var testFile = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
+            using (var file = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     ReadOffset = readOffset
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 1);
@@ -63,11 +63,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void ReadChr(string chr)
         {
             // Arrange
-            using (var testFile = new TempFileCreator(new RegionGenerator { Chr = chr }))
+            using (var file = new TempFileCreator(new RegionGenerator { Chr = chr }))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey(chr));
@@ -80,11 +80,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void FailReadChr(string chr)
         {
             // Arrange
-            using (var testFile = new TempFileCreator(new RegionGenerator { Chr = "chr1" }))
+            using (var file = new TempFileCreator(new RegionGenerator { Chr = "chr1" }))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey(chr));
@@ -96,11 +96,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // ACt
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands.ContainsKey(rg.Strand));
@@ -112,11 +112,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Left == rg.Left);
@@ -127,11 +127,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void FailReadLeft()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\t10V\t20\tGeUtilities_01\t123.4"))
+            using (var file = new TempFileCreator("chr1\t10V\t20\tGeUtilities_01\t123.4"))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -143,11 +143,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (TempFileCreator testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Right == rg.Right);
@@ -158,11 +158,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void FailReadRightInvalidValue()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\t10\t20V\tGeUtilities_01\t123.4"))
+            using (var file = new TempFileCreator("chr1\t10\t20V\tGeUtilities_01\t123.4"))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -173,11 +173,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void FailReadRightColumnIndexOutOfRange()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123.4"))
+            using (var file = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123.4"))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Right = 10 });
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -189,11 +189,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Name == rg.Name);
@@ -205,11 +205,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Value == rg.Value);
@@ -220,11 +220,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void FailReadValue()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
+            using (var file = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -236,11 +236,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);

--- a/GeUtilities.Tests/IntervalParsers/BED/Features.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/Features.cs
@@ -36,14 +36,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void DropPeaksHavingInvalidPValue()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
+            using (var file = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     DropPeakIfInvalidValue = true
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -55,7 +55,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             double defaultValue = 1122.33;
-            using (var testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
+            using (var file = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
@@ -63,7 +63,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                     DropPeakIfInvalidValue = false,
                     DefaultValue = defaultValue
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes["chr1"].Strands['*'].Intervals[0].Value == defaultValue);
@@ -75,14 +75,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Value = 9 })
                 {
                     DropPeakIfInvalidValue = true
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey(rg.Chr));
@@ -94,14 +94,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Value = 9 })
                 {
                     DropPeakIfInvalidValue = false
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey(rg.Chr));
@@ -117,14 +117,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator { Value = convertedValue };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     PValueFormat = pvalueFormat
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Value == originalValue);
@@ -140,14 +140,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg, peaksCount: numberOfPeaksToWrite))
+            using (var file = new TempFileCreator(rg, peaksCount: numberOfPeaksToWrite))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     MaxLinesToRead = numberOfPeaksToRead
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == Math.Min(numberOfPeaksToWrite, numberOfPeaksToRead));
@@ -159,14 +159,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg, peaksCount: 4))
+            using (var file = new TempFileCreator(rg, peaksCount: 4))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     MaxLinesToRead = 0
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 0);
@@ -178,14 +178,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Name = 12 })
                 {
                     DropPeakIfInvalidValue = false
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Name == null);
@@ -199,14 +199,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     HashFunction = hashFunction
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);
@@ -218,14 +218,14 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Value = 9 })
                 {
                     DropPeakIfInvalidValue = true
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Messages.Count > 0);
@@ -239,7 +239,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator { Chr = chr };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
@@ -247,7 +247,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                     Assembly = Assemblies.hg19,
                     ReadOnlyAssemblyChrs = true
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey("chr" + chr));
@@ -261,7 +261,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator { Chr = chr };
-            using (TempFileCreator testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
@@ -269,7 +269,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                     Assembly = Assemblies.hg19,
                     ReadOnlyAssemblyChrs = true
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 0);
@@ -284,7 +284,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator { Chr = chr };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>()
@@ -292,7 +292,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                     Assembly = Assemblies.hg19,
                     ReadOnlyAssemblyChrs = false
                 };
-                parser.Parse(testFile.TempFilePath);
+                parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parser.ExcessChrs.Count == 1);
@@ -304,7 +304,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator { Chr = "chr1" };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
@@ -312,7 +312,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                     Assembly = Assemblies.hg19,
                     ReadOnlyAssemblyChrs = false
                 };
-                parser.Parse(testFile.TempFilePath);
+                parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parser.MissingChrs.Count == References.GetGenomeSizes(Assemblies.hg19).Count - 1);
@@ -324,11 +324,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             var rg = new RegionGenerator { SummitColumn = 10, StrandColumn = 11 };
-            using (var testFile = new TempFileCreator(rg, headerLineCount: 2, peaksCount: 10))
+            using (var file = new TempFileCreator(rg, headerLineCount: 2, peaksCount: 10))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == 10);
@@ -339,11 +339,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         public void AvoidEmptyLines()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("             "))
+            using (var file = new TempFileCreator("             "))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 0);
@@ -362,11 +362,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                 "chr3\t50\t60\tGeUtilities_02\t0.001",
                 "chr4\t70\t80\tGeUtilities_03\t0.0001",
             };
-            using (var testFile = new TempFileCreator(peaks))
+            using (var file = new TempFileCreator(peaks))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.PValueMax.CompareTo(p) == 0);
@@ -385,11 +385,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                 "chr3\t50\t60\tGeUtilities_02\t0.01",
                 "chr4\t70\t80\tGeUtilities_03\t0.001",
             };
-            using (var testFile = new TempFileCreator(peaks))
+            using (var file = new TempFileCreator(peaks))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.PValueMin.CompareTo(p) == 0);
@@ -407,11 +407,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
                 "chr3\t50\t60\tGeUtilities_02\t0.001",
                 "chr4\t70\t80\tGeUtilities_03\t0.0001",
             };
-            using (var testFile = new TempFileCreator(peaks))
+            using (var file = new TempFileCreator(peaks))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedData.PValueMean == 0.027775);

--- a/GeUtilities.Tests/IntervalParsers/BED/Features.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/Features.cs
@@ -22,10 +22,10 @@ namespace GeUtilities.Tests.IntervalParsers.BED
         {
             // Arrange
             string fileName = "a_file_name_which_does_not_exist_1234567890";
-            var parser = new BEDParser<ChIPSeqPeak>(fileName);
+            var parser = new BEDParser<ChIPSeqPeak>();
 
             // Act
-            Exception exception = Assert.Throws<FileNotFoundException>(() => parser.Parse());
+            Exception exception = Assert.Throws<FileNotFoundException>(() => parser.Parse(fileName));
 
             // Assert
             Assert.False(String.IsNullOrEmpty(exception.Message));
@@ -39,11 +39,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     DropPeakIfInvalidValue = true
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -58,12 +58,12 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     DropPeakIfInvalidValue = false,
                     DefaultValue = defaultValue
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes["chr1"].Strands['*'].Intervals[0].Value == defaultValue);
@@ -78,11 +78,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, new BEDColumns() { Value = 9 })
+                var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Value = 9 })
                 {
                     DropPeakIfInvalidValue = true
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey(rg.Chr));
@@ -97,11 +97,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, new BEDColumns() { Value = 9 })
+                var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Value = 9 })
                 {
                     DropPeakIfInvalidValue = false
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey(rg.Chr));
@@ -120,11 +120,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     PValueFormat = pvalueFormat
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Value == originalValue);
@@ -143,11 +143,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg, peaksCount: numberOfPeaksToWrite))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     MaxLinesToRead = numberOfPeaksToRead
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == Math.Min(numberOfPeaksToWrite, numberOfPeaksToRead));
@@ -162,11 +162,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg, peaksCount: 4))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     MaxLinesToRead = 0
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 0);
@@ -181,11 +181,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, new BEDColumns() { Name = 12 })
+                var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Name = 12 })
                 {
                     DropPeakIfInvalidValue = false
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Name == null);
@@ -202,11 +202,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     HashFunction = hashFunction
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);
@@ -221,11 +221,11 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath, new BEDColumns() { Value = 9 })
+                var parser = new BEDParser<ChIPSeqPeak>(new BEDColumns() { Value = 9 })
                 {
                     DropPeakIfInvalidValue = true
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Messages.Count > 0);
@@ -242,12 +242,12 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     Assembly = Assemblies.hg19,
                     ReadOnlyAssemblyChrs = true
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey("chr" + chr));
@@ -264,12 +264,12 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (TempFileCreator testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     Assembly = Assemblies.hg19,
                     ReadOnlyAssemblyChrs = true
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 0);
@@ -287,12 +287,12 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                BEDParser<ChIPSeqPeak> parser = new BEDParser<ChIPSeqPeak>()
                 {
                     Assembly = Assemblies.hg19,
                     ReadOnlyAssemblyChrs = false
                 };
-                parser.Parse();
+                parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parser.ExcessChrs.Count == 1);
@@ -307,12 +307,12 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     Assembly = Assemblies.hg19,
                     ReadOnlyAssemblyChrs = false
                 };
-                parser.Parse();
+                parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parser.MissingChrs.Count == References.GetGenomeSizes(Assemblies.hg19).Count - 1);
@@ -327,8 +327,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(rg, headerLineCount: 2, peaksCount: 10))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == 10);
@@ -342,8 +342,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator("             "))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 0);
@@ -365,8 +365,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(peaks))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.PValueMax.CompareTo(p) == 0);
@@ -388,8 +388,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(peaks))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.PValueMin.CompareTo(p) == 0);
@@ -410,8 +410,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
             using (var testFile = new TempFileCreator(peaks))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.PValueMean == 0.027775);

--- a/GeUtilities.Tests/IntervalParsers/BED/TempFileCreator.cs
+++ b/GeUtilities.Tests/IntervalParsers/BED/TempFileCreator.cs
@@ -12,23 +12,23 @@ namespace GeUtilities.Tests.IntervalParsers.BED
 {
     internal class TempFileCreator : IDisposable
     {
-        private readonly string _tempFilePath;
-        public string TempFilePath { get { return _tempFilePath; } }
+        private readonly string _path;
+        public string Path { get { return _path; } }
 
         public TempFileCreator() : this(new RegionGenerator()) { }
 
         public TempFileCreator(string peak)
         {
-            _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".bed";
-            FileStream stream = File.Create(TempFilePath);
+            _path = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".bed";
+            FileStream stream = File.Create(Path);
             using (StreamWriter writter = new StreamWriter(stream))
                 writter.WriteLine(peak);
         }
 
         public TempFileCreator(string[] peaks)
         {
-            _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".bed";
-            FileStream stream = File.Create(TempFilePath);
+            _path = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".bed";
+            FileStream stream = File.Create(Path);
             using (StreamWriter writer = new StreamWriter(stream))
                 foreach (var peak in peaks)
                     writer.WriteLine(peak);
@@ -36,8 +36,8 @@ namespace GeUtilities.Tests.IntervalParsers.BED
 
         public TempFileCreator(RegionGenerator columns, int headerLineCount = 0, int peaksCount = 1)
         {
-            _tempFilePath = Path.GetTempPath() + Guid.NewGuid().ToString() + ".bed";
-            FileStream stream = File.Create(TempFilePath);
+            _path = System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".bed";
+            FileStream stream = File.Create(Path);
             using (StreamWriter writer = new StreamWriter(stream))
             {
                 while (headerLineCount-- > 0)
@@ -63,7 +63,7 @@ namespace GeUtilities.Tests.IntervalParsers.BED
 
         protected virtual void Dispose(bool disposing)
         {
-            File.Delete(_tempFilePath);
+            File.Delete(_path);
         }
     }
 }

--- a/GeUtilities.Tests/IntervalParsers/GTF/ColumnsOrder.cs
+++ b/GeUtilities.Tests/IntervalParsers/GTF/ColumnsOrder.cs
@@ -18,8 +18,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedFeature = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedFeature = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedFeature.CompareTo(rg.GFeature) == 0);

--- a/GeUtilities.Tests/IntervalParsers/GTF/ColumnsOrder.cs
+++ b/GeUtilities.Tests/IntervalParsers/GTF/ColumnsOrder.cs
@@ -15,11 +15,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedFeature = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedFeature = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedFeature.CompareTo(rg.GFeature) == 0);
@@ -53,10 +53,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
                 AttributeColumn = attributeColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedGTF = Features.ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = Features.ParseGTF(file.TempFilePath, rg);
                 var parsedFeature = parsedGTF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
@@ -79,10 +79,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             rg.StrandColumn = 19;
             rg.FeatureColumn = 8;
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedGTF = Features.ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = Features.ParseGTF(file.TempFilePath, rg);
                 var parsedFeature = parsedGTF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
@@ -106,10 +106,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
                 SourceColumn = sourceColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedGTF = Features.ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = Features.ParseGTF(file.TempFilePath, rg);
                 var parsedFeature = parsedGTF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
@@ -133,10 +133,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
                 FeatureColumn = featureColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedGTF = Features.ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = Features.ParseGTF(file.TempFilePath, rg);
                 var parsedFeature = parsedGTF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
@@ -154,10 +154,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
                 FeatureColumn = 10
             };
 
-            using (var testFile = new TempFileCreator("chr1\tDi4\t.\t10\t20\t100.0\t*\t0\tatt1=1;att2=v2"))
+            using (var file = new TempFileCreator("chr1\tDi4\t.\t10\t20\t100.0\t*\t0\tatt1=1;att2=v2"))
             {
                 // Act
-                var parsedGTF = Features.ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = Features.ParseGTF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedGTF.Chromosomes.ContainsKey("chr1"));
@@ -180,10 +180,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
                 ScoreColumn = scoreColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedGTF = Features.ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = Features.ParseGTF(file.TempFilePath, rg);
                 var parsedFeature = parsedGTF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
@@ -207,10 +207,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
                 FrameColumn = frameColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedGTF = Features.ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = Features.ParseGTF(file.TempFilePath, rg);
                 var parsedFeature = parsedGTF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
@@ -234,10 +234,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
                 AttributeColumn = attributeColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedGTF = Features.ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = Features.ParseGTF(file.TempFilePath, rg);
                 var parsedFeature = parsedGTF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/IntervalParsers/GTF/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/GTF/ConcreteClassArguments.cs
@@ -17,8 +17,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser(testFile.TempFilePath);
-                var parsedFeature = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new GTFParser();
+                var parsedFeature = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedFeature.CompareTo(rg.GFeature) == 0);
@@ -33,8 +33,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser(testFile.TempFilePath, rg.Columns);
-                var parsedFeature = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new GTFParser(rg.Columns);
+                var parsedFeature = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedFeature.CompareTo(rg.GFeature) == 0);

--- a/GeUtilities.Tests/IntervalParsers/GTF/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/GTF/ConcreteClassArguments.cs
@@ -14,11 +14,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser();
-                var parsedFeature = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedFeature = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedFeature.CompareTo(rg.GFeature) == 0);
@@ -30,11 +30,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser(rg.Columns);
-                var parsedFeature = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedFeature = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedFeature.CompareTo(rg.GFeature) == 0);

--- a/GeUtilities.Tests/IntervalParsers/GTF/DefaultArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/GTF/DefaultArguments.cs
@@ -19,14 +19,14 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         public void AvoidHeader(int headerCount, byte readOffset)
         {
             // Arrange
-            using (var testFile = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
+            using (var file = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>()
                 {
                     ReadOffset = readOffset
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 1);
@@ -44,11 +44,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator { Chr = chr };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey(chr));
@@ -62,11 +62,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator { Chr = "chr1" };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey(chr));
@@ -78,11 +78,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands.ContainsKey(rg.Strand));
@@ -94,11 +94,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator { Left = 10 };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Left == rg.Left);
@@ -109,11 +109,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         public void FailReadLeft()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\tSource\tFeature\t10V\t20\t100.0\t*\t0\tatt1=1;att2=v2"))
+            using (var file = new TempFileCreator("chr1\tSource\tFeature\t10V\t20\t100.0\t*\t0\tatt1=1;att2=v2"))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -125,11 +125,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator { Right = 20 };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Right == rg.Right);
@@ -140,11 +140,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         public void FailReadRight()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\tSource\tFeature\t10\t20V\t100.0\t*\t0\tatt1=1;att2=v2"))
+            using (var file = new TempFileCreator("chr1\tSource\tFeature\t10\t20V\t100.0\t*\t0\tatt1=1;att2=v2"))
             {
                 // ACt
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -156,11 +156,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator { Source = "Source_01" };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Source == rg.Source);
@@ -172,11 +172,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator { Feature = "Feature_01" };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Feature == rg.Feature);
@@ -188,11 +188,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator { Score = 123.456 };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Score == rg.Score);
@@ -204,11 +204,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator { Attribute = "att1=at1;att2=at2;att3=3" };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Attribute == rg.Attribute);
@@ -220,11 +220,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new GTFParser<GeneralFeature>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);

--- a/GeUtilities.Tests/IntervalParsers/GTF/DefaultArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/GTF/DefaultArguments.cs
@@ -22,11 +22,11 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath)
+                var parser = new GTFParser<GeneralFeature>()
                 {
                     ReadOffset = readOffset
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 1);
@@ -47,8 +47,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey(chr));
@@ -65,8 +65,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey(chr));
@@ -81,8 +81,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands.ContainsKey(rg.Strand));
@@ -97,8 +97,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Left == rg.Left);
@@ -112,8 +112,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator("chr1\tSource\tFeature\t10V\t20\t100.0\t*\t0\tatt1=1;att2=v2"))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -128,8 +128,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Right == rg.Right);
@@ -143,8 +143,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator("chr1\tSource\tFeature\t10\t20V\t100.0\t*\t0\tatt1=1;att2=v2"))
             {
                 // ACt
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -159,8 +159,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Source == rg.Source);
@@ -175,8 +175,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Feature == rg.Feature);
@@ -191,8 +191,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Score == rg.Score);
@@ -207,8 +207,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Attribute == rg.Attribute);
@@ -223,8 +223,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new GTFParser<GeneralFeature>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new GTFParser<GeneralFeature>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);

--- a/GeUtilities.Tests/IntervalParsers/GTF/Features.cs
+++ b/GeUtilities.Tests/IntervalParsers/GTF/Features.cs
@@ -12,8 +12,8 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
     {
         internal static GTF<GeneralFeature> ParseGTF(string filePath, RegionGenerator rg)
         {
-            var parser = new GTFParser<GeneralFeature>(filePath, rg.Columns);
-            return parser.Parse();
+            var parser = new GTFParser<GeneralFeature>(rg.Columns);
+            return parser.Parse(filePath);
         }
 
         [Fact]

--- a/GeUtilities.Tests/IntervalParsers/GTF/Features.cs
+++ b/GeUtilities.Tests/IntervalParsers/GTF/Features.cs
@@ -22,10 +22,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             // Arrange
             var rg = new RegionGenerator { Feature = "feature" };
             int featureCount = 5;
-            using (var testFile = new TempFileCreator(rg, featuresCount: featureCount))
+            using (var file = new TempFileCreator(rg, featuresCount: featureCount))
             {
                 // Act
-                var parsedGTF = ParseGTF(testFile.TempFilePath, rg);
+                var parsedGTF = ParseGTF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.True(parsedGTF.DeterminedFeatures[rg.Feature] == featureCount);
@@ -40,10 +40,10 @@ namespace GeUtilities.Tests.IntervalParsers.GTF
             {
                 StrandColumn = 12
             };
-            using (var testFile = new TempFileCreator(rg, featuresCount: 10, headerLineCount: 2))
+            using (var file = new TempFileCreator(rg, featuresCount: 10, headerLineCount: 2))
             {
                 // Act
-                var parsedData = ParseGTF(testFile.TempFilePath, rg);
+                var parsedData = ParseGTF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == 10);

--- a/GeUtilities.Tests/IntervalParsers/Model/ParsedIntervals.cs
+++ b/GeUtilities.Tests/IntervalParsers/Model/ParsedIntervals.cs
@@ -21,8 +21,8 @@ namespace GeUtilities.Tests.IntervalParsers.ModelTests
             using (var testFile = new TempFileCreator(peak))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedBED = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedBED = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedBED.FileHashKey != 0);
@@ -37,8 +37,8 @@ namespace GeUtilities.Tests.IntervalParsers.ModelTests
             using (var testFile = new TempFileCreator(peak))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedBED = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedBED = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedBED.FileName == Path.GetFileName(testFile.TempFilePath));
@@ -53,8 +53,8 @@ namespace GeUtilities.Tests.IntervalParsers.ModelTests
             using (var testFile = new TempFileCreator(peak))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                var parsedBED = parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                var parsedBED = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedBED.FilePath == Path.GetFullPath(testFile.TempFilePath));
@@ -72,11 +72,11 @@ namespace GeUtilities.Tests.IntervalParsers.ModelTests
             using (var testFile = new TempFileCreator(peak))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     Assembly = assembly
                 };
-                var parsedBED = parser.Parse();
+                var parsedBED = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedBED.Assembly == assembly);

--- a/GeUtilities.Tests/IntervalParsers/Model/ParsedIntervals.cs
+++ b/GeUtilities.Tests/IntervalParsers/Model/ParsedIntervals.cs
@@ -18,11 +18,11 @@ namespace GeUtilities.Tests.IntervalParsers.ModelTests
         {
             // Arrange
             string peak = "chr1\t10\t20\tName\t100.0";
-            using (var testFile = new TempFileCreator(peak))
+            using (var file = new TempFileCreator(peak))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedBED = parser.Parse(testFile.TempFilePath);
+                var parsedBED = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedBED.FileHashKey != 0);
@@ -34,14 +34,14 @@ namespace GeUtilities.Tests.IntervalParsers.ModelTests
         {
             // Arrange
             string peak = "chr1\t10\t20\tName\t100.0";
-            using (var testFile = new TempFileCreator(peak))
+            using (var file = new TempFileCreator(peak))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedBED = parser.Parse(testFile.TempFilePath);
+                var parsedBED = parser.Parse(file.Path);
 
                 // Assert
-                Assert.True(parsedBED.FileName == Path.GetFileName(testFile.TempFilePath));
+                Assert.True(parsedBED.FileName == Path.GetFileName(file.Path));
             }
         }
 
@@ -50,14 +50,14 @@ namespace GeUtilities.Tests.IntervalParsers.ModelTests
         {
             // Arrange
             string peak = "chr1\t10\t20\tName\t100.0";
-            using (var testFile = new TempFileCreator(peak))
+            using (var file = new TempFileCreator(peak))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                var parsedBED = parser.Parse(testFile.TempFilePath);
+                var parsedBED = parser.Parse(file.Path);
 
                 // Assert
-                Assert.True(parsedBED.FilePath == Path.GetFullPath(testFile.TempFilePath));
+                Assert.True(parsedBED.FilePath == Path.GetFullPath(file.Path));
             }
         }
 
@@ -69,14 +69,14 @@ namespace GeUtilities.Tests.IntervalParsers.ModelTests
         {
             // Arrange
             string peak = "chr1\t10\t20\tName\t100.0";
-            using (var testFile = new TempFileCreator(peak))
+            using (var file = new TempFileCreator(peak))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     Assembly = assembly
                 };
-                var parsedBED = parser.Parse(testFile.TempFilePath);
+                var parsedBED = parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parsedBED.Assembly == assembly);

--- a/GeUtilities.Tests/IntervalParsers/RefSeq/ColumnsOrder.cs
+++ b/GeUtilities.Tests/IntervalParsers/RefSeq/ColumnsOrder.cs
@@ -38,11 +38,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
                 StrandColumn = strandColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>(rg.Columns);
-                var parsedGene = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedGene = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedGene.CompareTo(rg.Gene) == 0);

--- a/GeUtilities.Tests/IntervalParsers/RefSeq/ColumnsOrder.cs
+++ b/GeUtilities.Tests/IntervalParsers/RefSeq/ColumnsOrder.cs
@@ -41,8 +41,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath, rg.Columns);
-                var parsedGene = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new RefSeqParser<Gene>(rg.Columns);
+                var parsedGene = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedGene.CompareTo(rg.Gene) == 0);

--- a/GeUtilities.Tests/IntervalParsers/RefSeq/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/RefSeq/ConcreteClassArguments.cs
@@ -17,8 +17,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser(testFile.TempFilePath);
-                var parsedGene = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new RefSeqParser();
+                var parsedGene = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedGene.CompareTo(rg.Gene) == 0);
@@ -33,8 +33,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser(testFile.TempFilePath, rg.Columns);
-                var parsedGene = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new RefSeqParser(rg.Columns);
+                var parsedGene = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedGene.CompareTo(rg.Gene) == 0);

--- a/GeUtilities.Tests/IntervalParsers/RefSeq/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/RefSeq/ConcreteClassArguments.cs
@@ -14,11 +14,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser();
-                var parsedGene = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedGene = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedGene.CompareTo(rg.Gene) == 0);
@@ -30,11 +30,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser(rg.Columns);
-                var parsedGene = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedGene = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedGene.CompareTo(rg.Gene) == 0);

--- a/GeUtilities.Tests/IntervalParsers/RefSeq/DefaultArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/RefSeq/DefaultArguments.cs
@@ -19,8 +19,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath);
-                var parsedGene = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new RefSeqParser<Gene>();
+                var parsedGene = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedGene.CompareTo(rg.Gene) == 0);
@@ -41,8 +41,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new RefSeqParser<Gene>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey(chr));
@@ -59,8 +59,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new RefSeqParser<Gene>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey(chr));
@@ -81,8 +81,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var genesParser = new RefSeqParser<Gene>(testFile.TempFilePath, rg.Columns);
-                var parsedData = genesParser.Parse();
+                var genesParser = new RefSeqParser<Gene>(rg.Columns);
+                var parsedData = genesParser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands.ContainsKey(strand));
@@ -97,8 +97,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new RefSeqParser<Gene>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].RefSeqID == rg.RefSeqID);
@@ -112,8 +112,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator("chr1\t10\t20\tRefSeq\tGeneSymbol"))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath, new RefSeqColumns() { RefSeqID = 10 });
-                var parsedData = parser.Parse();
+                var parser = new RefSeqParser<Gene>(new RefSeqColumns() { RefSeqID = 10 });
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -128,8 +128,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new RefSeqParser<Gene>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].GeneSymbol == rg.GeneSymbol);
@@ -143,8 +143,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator("chr1\t10\t20\tRefSeq\tGeneSymbol"))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath, new RefSeqColumns() { GeneSeymbol = 10 });
-                var parsedData = parser.Parse();
+                var parser = new RefSeqParser<Gene>(new RefSeqColumns() { GeneSeymbol = 10 });
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -163,11 +163,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath)
+                var parser = new RefSeqParser<Gene>()
                 {
                     ReadOffset = readOffset
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 1);
@@ -182,8 +182,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new RefSeqParser<Gene>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);

--- a/GeUtilities.Tests/IntervalParsers/RefSeq/DefaultArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/RefSeq/DefaultArguments.cs
@@ -16,11 +16,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>();
-                var parsedGene = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedGene = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedGene.CompareTo(rg.Gene) == 0);
@@ -38,11 +38,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator { Chr = chr };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.ContainsKey(chr));
@@ -56,11 +56,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator { Chr = "chr1" };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey(chr));
@@ -78,11 +78,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
                 Strand = strand,
                 StrandColumn = 5
             };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var genesParser = new RefSeqParser<Gene>(rg.Columns);
-                var parsedData = genesParser.Parse(testFile.TempFilePath);
+                var parsedData = genesParser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands.ContainsKey(strand));
@@ -94,11 +94,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator { RefSeqID = "RefSeqID_001" };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].RefSeqID == rg.RefSeqID);
@@ -109,11 +109,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         public void FailReadRefSeqID()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\t10\t20\tRefSeq\tGeneSymbol"))
+            using (var file = new TempFileCreator("chr1\t10\t20\tRefSeq\tGeneSymbol"))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>(new RefSeqColumns() { RefSeqID = 10 });
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -125,11 +125,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator { GeneSymbol = "Symbol_001" };
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].GeneSymbol == rg.GeneSymbol);
@@ -140,11 +140,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         public void FailReadGeneSymbol()
         {
             // Arrange
-            using (var testFile = new TempFileCreator("chr1\t10\t20\tRefSeq\tGeneSymbol"))
+            using (var file = new TempFileCreator("chr1\t10\t20\tRefSeq\tGeneSymbol"))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>(new RefSeqColumns() { GeneSeymbol = 10 });
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.False(parsedData.Chromosomes.ContainsKey("chr1"));
@@ -160,14 +160,14 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         public void AvoidHeader(int headerCount, byte readOffset)
         {
             // Arrange
-            using (var testFile = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
+            using (var file = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>()
                 {
                     ReadOffset = readOffset
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 1);
@@ -179,11 +179,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);

--- a/GeUtilities.Tests/IntervalParsers/RefSeq/Features.cs
+++ b/GeUtilities.Tests/IntervalParsers/RefSeq/Features.cs
@@ -18,8 +18,8 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
             using (var testFile = new TempFileCreator(rg, genesCount: 10, headerLineCount: 2))
             {
                 // Act
-                var parser = new RefSeqParser<Gene>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new RefSeqParser<Gene>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == 10);

--- a/GeUtilities.Tests/IntervalParsers/RefSeq/Features.cs
+++ b/GeUtilities.Tests/IntervalParsers/RefSeq/Features.cs
@@ -15,11 +15,11 @@ namespace GeUtilities.Tests.IntervalParsers.RefSeq
         {
             // Arrange
             var rg = new RegionGenerator { StrandColumn = 12 };
-            using (var testFile = new TempFileCreator(rg, genesCount: 10, headerLineCount: 2))
+            using (var file = new TempFileCreator(rg, genesCount: 10, headerLineCount: 2))
             {
                 // Act
                 var parser = new RefSeqParser<Gene>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == 10);

--- a/GeUtilities.Tests/IntervalParsers/Stats/BEDStats.cs
+++ b/GeUtilities.Tests/IntervalParsers/Stats/BEDStats.cs
@@ -89,11 +89,11 @@ namespace GeUtilities.Tests.IntervalParsers.TStats
 
             using (var testFile = new TempFileCreator(peaks))
             {
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     PValueFormat = PValueFormats.SameAsInput
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 Assert.True(parsedData.Chromosomes["chr1"].Statistics.PValueHighest == 0.1);
             }
@@ -112,11 +112,11 @@ namespace GeUtilities.Tests.IntervalParsers.TStats
 
             using (var testFile = new TempFileCreator(peaks))
             {
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath)
+                var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     PValueFormat = PValueFormats.SameAsInput
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 Assert.True(parsedData.Statistics.PValueHighest == 0.2);
             }

--- a/GeUtilities.Tests/IntervalParsers/Stats/BEDStats.cs
+++ b/GeUtilities.Tests/IntervalParsers/Stats/BEDStats.cs
@@ -87,13 +87,13 @@ namespace GeUtilities.Tests.IntervalParsers.TStats
                 "chr2\t10\t20\tGeUtilities_00\t0.2",
             };
 
-            using (var testFile = new TempFileCreator(peaks))
+            using (var file = new TempFileCreator(peaks))
             {
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     PValueFormat = PValueFormats.SameAsInput
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 Assert.True(parsedData.Chromosomes["chr1"].Statistics.PValueHighest == 0.1);
             }
@@ -110,13 +110,13 @@ namespace GeUtilities.Tests.IntervalParsers.TStats
                 "chr2\t10\t20\tGeUtilities_00\t0.2",
             };
 
-            using (var testFile = new TempFileCreator(peaks))
+            using (var file = new TempFileCreator(peaks))
             {
                 var parser = new BEDParser<ChIPSeqPeak>()
                 {
                     PValueFormat = PValueFormats.SameAsInput
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.Path);
 
                 Assert.True(parsedData.Statistics.PValueHighest == 0.2);
             }

--- a/GeUtilities.Tests/IntervalParsers/Status/Status.cs
+++ b/GeUtilities.Tests/IntervalParsers/Status/Status.cs
@@ -25,7 +25,7 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
         public void Initial()
         {
             // Arrange
-            using (var testFile = new BED.TempFileCreator(new BED.RegionGenerator()))
+            using (var file = new BED.TempFileCreator(new BED.RegionGenerator()))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
@@ -39,11 +39,11 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
         public void CompletedBED()
         {
             // Arrange
-            using (var testFile = new BED.TempFileCreator(new BED.RegionGenerator()))
+            using (var file = new BED.TempFileCreator(new BED.RegionGenerator()))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                parser.Parse(testFile.TempFilePath);
+                parser.Parse(file.Path);
 
                 // Assert
                 Assert.True(parser.Status == "100");
@@ -54,11 +54,11 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
         public void CompletedGeneralFeature()
         {
             // Arrange
-            using (var testFile = new GTF.TempFileCreator(new GTF.RegionGenerator()))
+            using (var file = new GTF.TempFileCreator(new GTF.RegionGenerator()))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                parser.Parse(testFile.TempFilePath);
+                parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parser.Status == "100");
@@ -69,11 +69,11 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
         public void CompletedRefSeqGenes()
         {
             // Arrange
-            using (var testFile = new RefSeq.TempFileCreator(new RefSeq.RegionGenerator()))
+            using (var file = new RefSeq.TempFileCreator(new RefSeq.RegionGenerator()))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                parser.Parse(testFile.TempFilePath);
+                parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parser.Status == "100");
@@ -84,11 +84,11 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
         public void CompletedVCF()
         {
             // Arrange
-            using (var testFile = new VCF.TempFileCreator(new VCF.RegionGenerator()))
+            using (var file = new VCF.TempFileCreator(new VCF.RegionGenerator()))
             {
                 // Act
                 var parser = new BEDParser<ChIPSeqPeak>();
-                parser.Parse(testFile.TempFilePath);
+                parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parser.Status == "100");
@@ -100,12 +100,12 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
         {
             // Arrange
             _previousStatus = -1;
-            using (var testFile = new BED.TempFileCreator(new BED.RegionGenerator(), peaksCount: 50))
+            using (var file = new BED.TempFileCreator(new BED.RegionGenerator(), peaksCount: 50))
             {
                 // Act
                 var bedParser = new BEDParser<ChIPSeqPeak>();
                 bedParser.StatusChanged += ParserStatusChanged;
-                bedParser.Parse(testFile.TempFilePath);
+                bedParser.Parse(file.Path);
 
                 // Asserted in 'ParserStatusChanged'
             }

--- a/GeUtilities.Tests/IntervalParsers/Status/Status.cs
+++ b/GeUtilities.Tests/IntervalParsers/Status/Status.cs
@@ -28,7 +28,7 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
             using (var testFile = new BED.TempFileCreator(new BED.RegionGenerator()))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                var parser = new BEDParser<ChIPSeqPeak>();
 
                 // Assert
                 Assert.True(parser.Status == "0");
@@ -42,8 +42,8 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
             using (var testFile = new BED.TempFileCreator(new BED.RegionGenerator()))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parser.Status == "100");
@@ -57,8 +57,8 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
             using (var testFile = new GTF.TempFileCreator(new GTF.RegionGenerator()))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parser.Status == "100");
@@ -72,8 +72,8 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
             using (var testFile = new RefSeq.TempFileCreator(new RefSeq.RegionGenerator()))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parser.Status == "100");
@@ -87,8 +87,8 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
             using (var testFile = new VCF.TempFileCreator(new VCF.RegionGenerator()))
             {
                 // Act
-                var parser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
-                parser.Parse();
+                var parser = new BEDParser<ChIPSeqPeak>();
+                parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parser.Status == "100");
@@ -103,9 +103,9 @@ namespace GeUtilities.Tests.IntervalParsers.TStatus
             using (var testFile = new BED.TempFileCreator(new BED.RegionGenerator(), peaksCount: 50))
             {
                 // Act
-                var bedParser = new BEDParser<ChIPSeqPeak>(testFile.TempFilePath);
+                var bedParser = new BEDParser<ChIPSeqPeak>();
                 bedParser.StatusChanged += ParserStatusChanged;
-                bedParser.Parse();
+                bedParser.Parse(testFile.TempFilePath);
 
                 // Asserted in 'ParserStatusChanged'
             }

--- a/GeUtilities.Tests/IntervalParsers/VCF/ColumnsOrder.cs
+++ b/GeUtilities.Tests/IntervalParsers/VCF/ColumnsOrder.cs
@@ -21,11 +21,11 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new VCFParser<Variant>();
-                var parsedVariant = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedVariant = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedVariant.CompareTo(rg.Variant) == 0);
@@ -59,10 +59,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
                 StrandColumn = strandColumn
             };
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
                 var parsedVariant = parsedVCF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
@@ -77,10 +77,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { PositionColumn = 20 };
             string line = "chr1\tXYZ\tAAC\tCCA\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -94,10 +94,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { IDColumn = 20 };
             string line = "chr1\t10\tAAC\tCCA\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -111,10 +111,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { RefbColumn = 20 };
             string line = "chr1\t10\tAAC\tCCA\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -128,10 +128,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { RefbColumn = 2 };
             string line = "chr1\t10\tXYZ\tCCA\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -145,10 +145,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { AltbColumn = 20 };
             string line = "chr1\t10\tAAC\tCCA\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -162,10 +162,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { AltbColumn = 3 };
             string line = "chr1\t10\tACC\tXYZ\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -179,10 +179,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { QualityColumn = 20 };
             string line = "chr1\t10\tACC\tCCA\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -196,10 +196,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { QualityColumn = 4 };
             string line = "chr1\t10\tACC\tCCA\t12.3.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -213,10 +213,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { FilterColumn = 20 };
             string line = "chr1\t10\tACC\tCCA\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -230,10 +230,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             var rg = new RegionGenerator() { InfoColumn = 20 };
             string line = "chr1\t10\tACC\tCCA\t123.456\tFilter\tInfo\t*";
 
-            using (var testFile = new TempFileCreator(line))
+            using (var file = new TempFileCreator(line))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
 
                 // Assert
                 Assert.False(parsedVCF.Chromosomes.ContainsKey("chr1"));
@@ -258,10 +258,10 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             };
             rg.InfoColumn = 12;
 
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parsedVCF = ParseVCF(testFile.TempFilePath, rg);
+                var parsedVCF = ParseVCF(file.TempFilePath, rg);
                 var parsedPeak = parsedVCF.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert

--- a/GeUtilities.Tests/IntervalParsers/VCF/ColumnsOrder.cs
+++ b/GeUtilities.Tests/IntervalParsers/VCF/ColumnsOrder.cs
@@ -12,8 +12,8 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
     {
         private VCF<Variant> ParseVCF(string filePath, RegionGenerator rg)
         {
-            var parser = new VCFParser<Variant>(filePath, rg.Columns);
-            return parser.Parse();
+            var parser = new VCFParser<Variant>(rg.Columns);
+            return parser.Parse(filePath);
         }
 
         [Fact]
@@ -24,8 +24,8 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new VCFParser<Variant>(testFile.TempFilePath);
-                var parsedVariant = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new VCFParser<Variant>();
+                var parsedVariant = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedVariant.CompareTo(rg.Variant) == 0);

--- a/GeUtilities.Tests/IntervalParsers/VCF/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/VCF/ConcreteClassArguments.cs
@@ -17,8 +17,8 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new VCFParser(testFile.TempFilePath);
-                var parsedVariant = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new VCFParser();
+                var parsedVariant = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedVariant.CompareTo(rg.Variant) == 0);
@@ -33,8 +33,8 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new VCFParser(testFile.TempFilePath, rg.Columns);
-                var parsedVariant = parser.Parse().Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parser = new VCFParser(rg.Columns);
+                var parsedVariant = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedVariant.CompareTo(rg.Variant) == 0);

--- a/GeUtilities.Tests/IntervalParsers/VCF/ConcreteClassArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/VCF/ConcreteClassArguments.cs
@@ -14,11 +14,11 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new VCFParser();
-                var parsedVariant = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedVariant = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedVariant.CompareTo(rg.Variant) == 0);
@@ -30,11 +30,11 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new VCFParser(rg.Columns);
-                var parsedVariant = parser.Parse(testFile.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
+                var parsedVariant = parser.Parse(file.TempFilePath).Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0];
 
                 // Assert
                 Assert.True(parsedVariant.CompareTo(rg.Variant) == 0);

--- a/GeUtilities.Tests/IntervalParsers/VCF/DefaultArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/VCF/DefaultArguments.cs
@@ -15,11 +15,11 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new VCFParser<Variant>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);
@@ -35,14 +35,14 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
         public void AvoidHeader(int headerCount, byte readOffset)
         {
             // Arrange
-            using (var testFile = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
+            using (var file = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
             {
                 // Act
                 var parser = new VCFParser<Variant>()
                 {
                     ReadOffset = readOffset
                 };
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 1);

--- a/GeUtilities.Tests/IntervalParsers/VCF/DefaultArguments.cs
+++ b/GeUtilities.Tests/IntervalParsers/VCF/DefaultArguments.cs
@@ -18,8 +18,8 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new VCFParser<Variant>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new VCFParser<Variant>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].HashKey != 0);
@@ -38,11 +38,11 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             using (var testFile = new TempFileCreator(new RegionGenerator(), headerLineCount: headerCount))
             {
                 // Act
-                var parser = new VCFParser<Variant>(testFile.TempFilePath)
+                var parser = new VCFParser<Variant>()
                 {
                     ReadOffset = readOffset
                 };
-                var parsedData = parser.Parse();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes.Count == 1);

--- a/GeUtilities.Tests/IntervalParsers/VCF/Features.cs
+++ b/GeUtilities.Tests/IntervalParsers/VCF/Features.cs
@@ -15,11 +15,11 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
         {
             // Arrange
             var rg = new RegionGenerator { StrandColumn = 12 };
-            using (var testFile = new TempFileCreator(rg, variantsCount: 10, headerLineCount: 2))
+            using (var file = new TempFileCreator(rg, variantsCount: 10, headerLineCount: 2))
             {
                 // Act
                 var parser = new VCFParser<Variant>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == 10);
@@ -40,11 +40,11 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
         {
             // Arrange
             var rg = new RegionGenerator();
-            using (var testFile = new TempFileCreator(rg))
+            using (var file = new TempFileCreator(rg))
             {
                 // Act
                 var parser = new VCFParser<Variant>();
-                var parsedData = parser.Parse(testFile.TempFilePath);
+                var parsedData = parser.Parse(file.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Right == rg.Position + 1);

--- a/GeUtilities.Tests/IntervalParsers/VCF/Features.cs
+++ b/GeUtilities.Tests/IntervalParsers/VCF/Features.cs
@@ -18,8 +18,8 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             using (var testFile = new TempFileCreator(rg, variantsCount: 10, headerLineCount: 2))
             {
                 // Act
-                var parser = new VCFParser<Variant>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new VCFParser<Variant>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.Count == 10);
@@ -43,8 +43,8 @@ namespace GeUtilities.Tests.IntervalParsers.VCF
             using (var testFile = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new VCFParser<Variant>(testFile.TempFilePath);
-                var parsedData = parser.Parse();
+                var parser = new VCFParser<Variant>();
+                var parsedData = parser.Parse(testFile.TempFilePath);
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Right == rg.Position + 1);

--- a/GeUtilities/IntervalParsers/BED/BEDParser.cs
+++ b/GeUtilities/IntervalParsers/BED/BEDParser.cs
@@ -9,12 +9,10 @@ namespace Genometric.GeUtilities.IntervalParsers
 {
     public class BEDParser : BEDParser<ChIPSeqPeak>
     {
-        public BEDParser(string sourceFilePath) :
-            this(sourceFilePath, new BEDColumns())
+        public BEDParser() : this(new BEDColumns())
         { }
 
-        public BEDParser(string sourceFilePath, BEDColumns columns) :
-            base(sourceFilePath, columns)
+        public BEDParser(BEDColumns columns) : base(columns)
         { }
     }
 }

--- a/GeUtilities/IntervalParsers/BED/BEDParserGeneric.cs
+++ b/GeUtilities/IntervalParsers/BED/BEDParserGeneric.cs
@@ -74,17 +74,14 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// <summary>
         /// Parse standard Browser Extensible Data (BED) format.
         /// </summary>
-        /// <param name="sourceFilePath">Full path of source file name.</param>
-        public BEDParser(string sourceFilePath) :
-            this(sourceFilePath, new BEDColumns())
+        public BEDParser() : this(new BEDColumns())
         { }
 
         /// <summary>
         /// Parse standard Browser Extensible Data (BED) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        public BEDParser(string sourceFilePath, BEDColumns columns) :
-            base(sourceFilePath, columns, new BED<I>())
+        public BEDParser(BEDColumns columns) : base(columns)
         {
             _nameColumn = columns.Name;
             _valueColumn = columns.Value;
@@ -168,9 +165,9 @@ namespace Genometric.GeUtilities.IntervalParsers
             return rtv;
         }
 
-        public new BED<I> Parse()
+        public BED<I> Parse(string sourceFilePath)
         {
-            var rtv = (BED<I>)base.Parse();
+            var rtv = (BED<I>)Parse(sourceFilePath, new BED<I>());
 
             if (_defaultValueUtilizationCount > 0)
                 Messages.Insert(0, "\tDefault p-value used for " + _defaultValueUtilizationCount.ToString() + " times");

--- a/GeUtilities/IntervalParsers/GTF/GTFParser.cs
+++ b/GeUtilities/IntervalParsers/GTF/GTFParser.cs
@@ -9,12 +9,10 @@ namespace Genometric.GeUtilities.IntervalParsers
 {
     public class GTFParser : GTFParser<GeneralFeature>
     {
-        public GTFParser(string sourceFilePath) :
-           this(sourceFilePath, new GTFColumns())
+        public GTFParser() : this(new GTFColumns())
         { }
 
-        public GTFParser(string sourceFilePath, GTFColumns columns) :
-           base(sourceFilePath, columns)
+        public GTFParser(GTFColumns columns) : base(columns)
         { }
     }
 }

--- a/GeUtilities/IntervalParsers/GTF/GTFParserGeneric.cs
+++ b/GeUtilities/IntervalParsers/GTF/GTFParserGeneric.cs
@@ -30,8 +30,7 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// Parse General Transfer Format (GTF) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        public GTFParser(string sourceFilePath) :
-            this(sourceFilePath, new GTFColumns())
+        public GTFParser() : this(new GTFColumns())
         { }
 
 
@@ -39,8 +38,7 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// Parse General Transfer Format (GTF) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        public GTFParser(string sourceFilePath, GTFColumns columns) :
-            base(sourceFilePath, columns, new GTF<I>())
+        public GTFParser(GTFColumns columns) : base(columns)
         {
             _sourceColumn = columns.Source;
             _featureColumn = columns.Feature;
@@ -96,9 +94,9 @@ namespace Genometric.GeUtilities.IntervalParsers
             return rtv;
         }
 
-        public new GTF<I> Parse()
+        public GTF<I> Parse(string sourceFilePath)
         {
-            var parsedData = (GTF<I>)base.Parse();
+            var parsedData = (GTF<I>)base.Parse(sourceFilePath, new GTF<I>());
             parsedData.DeterminedFeatures = new Dictionary<string, int>(_features);
             Status = "100";
             return parsedData;

--- a/GeUtilities/IntervalParsers/Parser.cs
+++ b/GeUtilities/IntervalParsers/Parser.cs
@@ -17,7 +17,7 @@ namespace Genometric.GeUtilities.IntervalParsers
         where I : IInterval<int>, new()
         where S : IStats<int>, new()
     {
-        private readonly ParsedIntervals<I, S> _data;
+        private ParsedIntervals<I, S> _data;
 
         private const UInt32 _FNVPrime_32 = 16777619;
         private const UInt32 _FNVOffsetBasis_32 = 2166136261;
@@ -25,7 +25,7 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// <summary>
         /// Full path of source file name.
         /// </summary>
-        private readonly string _sourceFilePath;
+        private string _sourceFilePath;
 
         /// <summary>
         /// Sets and gets the column number of chromosome name.
@@ -122,10 +122,10 @@ namespace Genometric.GeUtilities.IntervalParsers
         private bool _readOnlyAssemblyChrs = true;
 
         public ReadOnlyCollection<string> ExcessChrs { get { return _excessChrs.AsReadOnly(); } }
-        private readonly List<string> _excessChrs;
+        private List<string> _excessChrs;
 
         public ReadOnlyCollection<string> MissingChrs { get { return _missingChrs.AsReadOnly(); } }
-        private readonly List<string> _missingChrs;
+        private List<string> _missingChrs;
 
         /// <summary>
         /// Sets and gets the hash function used to create hash 
@@ -141,37 +141,54 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// </summary>
         public Assemblies Assembly { set; get; }
 
-        protected Parser(string sourceFilePath, BaseColumns columns, ParsedIntervals<I, S> data)
+        protected Parser(BaseColumns columns)
         {
-            _sourceFilePath = sourceFilePath;
             _chrColumn = columns.Chr;
             _leftColumn = columns.Left;
             _rightColumn = columns.Right;
             _strandColumn = columns.Strand;
+            MaxLinesToRead = uint.MaxValue;
+        }
+
+        protected ParsedIntervals<I, S> Parse(string sourceFilePath, ParsedIntervals<I, S> data)
+        {
+            _sourceFilePath = sourceFilePath;
             _data = data;
             _data.FilePath = Path.GetFullPath(_sourceFilePath);
             _data.FileName = Path.GetFileName(_sourceFilePath);
             _data.FileHashKey = GetFileHashKey(_data.FilePath);
             _excessChrs = new List<string>();
             _missingChrs = new List<string>();
-            MaxLinesToRead = uint.MaxValue;
+            Messages = new List<string>();
+
+            _assemblyData = References.GetGenomeSizes(Assembly);
+            if (!File.Exists(_sourceFilePath))
+                throw new FileNotFoundException(string.Format("The file `{0}` does not exist or is inaccessible.", _sourceFilePath));
+
+            Parse();
+
+            if (_dropedLinesCount > 0)
+                Messages.Insert(0, "\t" + _dropedLinesCount.ToString() + " Lines dropped");
+            _data.Messages = Messages;
+
+            if (Assembly != Assemblies.Unknown)
+                ReadMissingAndExcessChrs();
+
+            _data.Assembly = Assembly;
+            return _data;
         }
 
         /// <summary>
         /// Reads the regions presented in source file; and generates chromosome-wide statistics.
         /// </summary>
         /// <returns>Returns parsed intervals.</returns>
-        protected ParsedIntervals<I, S> Parse()
+        private void Parse()
         {
-            _assemblyData = References.GetGenomeSizes(Assembly);
-            if (!File.Exists(_sourceFilePath))
-                throw new FileNotFoundException(string.Format("The file `{0}` does not exist or is inaccessible.", _sourceFilePath));
-
             int left = 0;
             int right = 0;
             string line;
             UInt32 lineCounter = 0;
-            Messages = new List<string>();
+
             DropReadingPeak = false;
             byte readOffset = ReadOffset;
 
@@ -257,16 +274,6 @@ namespace Genometric.GeUtilities.IntervalParsers
                     }
                 }
             }
-
-            if (_dropedLinesCount > 0)
-                Messages.Insert(0, "\t" + _dropedLinesCount.ToString() + " Lines dropped");
-            _data.Messages = Messages;
-
-            if (Assembly != Assemblies.Unknown)
-                ReadMissingAndExcessChrs();
-
-            _data.Assembly = Assembly;
-            return _data;
         }
 
         /// <summary>

--- a/GeUtilities/IntervalParsers/RefSeq/RefSeqParser.cs
+++ b/GeUtilities/IntervalParsers/RefSeq/RefSeqParser.cs
@@ -9,12 +9,10 @@ namespace Genometric.GeUtilities.IntervalParsers
 {
     public class RefSeqParser : RefSeqParser<Gene>
     {
-        public RefSeqParser(string sourceFilePath) :
-            this(sourceFilePath, new RefSeqColumns())
+        public RefSeqParser() : this(new RefSeqColumns())
         { }
 
-        public RefSeqParser(string sourceFilePath, RefSeqColumns columns) :
-            base(sourceFilePath, columns)
+        public RefSeqParser(RefSeqColumns columns) : base(columns)
         { }
     }
 }

--- a/GeUtilities/IntervalParsers/RefSeq/RefSeqParserGeneric.cs
+++ b/GeUtilities/IntervalParsers/RefSeq/RefSeqParserGeneric.cs
@@ -73,9 +73,9 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// Reads the regions presented in source file and generates chromosome-wide statistics regarding regions length and p-values. 
         /// </summary>
         /// <returns>Returns an object of Input_BED_Data class</returns>
-        public new RefSeq<I> Parse(string sourceFilePath)
+        public RefSeq<I> Parse(string sourceFilePath)
         {
-            var parsingResult = (RefSeq<I>)base.Parse(sourceFilePath, new RefSeq<I>());
+            var parsingResult = (RefSeq<I>)Parse(sourceFilePath, new RefSeq<I>());
             Status = "100";
             return parsingResult;
         }

--- a/GeUtilities/IntervalParsers/RefSeq/RefSeqParserGeneric.cs
+++ b/GeUtilities/IntervalParsers/RefSeq/RefSeqParserGeneric.cs
@@ -28,8 +28,7 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// Parse refseq genes presented in tab-delimited text file.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
-        public RefSeqParser(string sourceFilePath) :
-            this(sourceFilePath, new RefSeqColumns())
+        public RefSeqParser() : this(new RefSeqColumns())
         { }
 
 
@@ -37,8 +36,7 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// Parse refseq genes presented in tab-delimited text file.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name</param>
-        public RefSeqParser(string sourceFilePath, RefSeqColumns columns) :
-            base(sourceFilePath, columns, new RefSeq<I>())
+        public RefSeqParser(RefSeqColumns columns) : base(columns)
         {
             _refSeqIDColumn = columns.RefSeqID;
             _geneColumn = columns.GeneSeymbol;
@@ -75,9 +73,9 @@ namespace Genometric.GeUtilities.IntervalParsers
         /// Reads the regions presented in source file and generates chromosome-wide statistics regarding regions length and p-values. 
         /// </summary>
         /// <returns>Returns an object of Input_BED_Data class</returns>
-        public new RefSeq<I> Parse()
+        public new RefSeq<I> Parse(string sourceFilePath)
         {
-            var parsingResult = (RefSeq<I>)base.Parse();
+            var parsingResult = (RefSeq<I>)base.Parse(sourceFilePath, new RefSeq<I>());
             Status = "100";
             return parsingResult;
         }

--- a/GeUtilities/IntervalParsers/VCF/VCFParser.cs
+++ b/GeUtilities/IntervalParsers/VCF/VCFParser.cs
@@ -9,14 +9,10 @@ namespace Genometric.GeUtilities.IntervalParsers
 {
     public class VCFParser : VCFParser<Variant>
     {
-        public VCFParser(
-            string sourceFilePath) :
-            this(sourceFilePath,new VCFColumns())
+        public VCFParser() : this(new VCFColumns())
         { }
 
-        public VCFParser(
-            string sourceFilePath, VCFColumns columns) :
-            base(sourceFilePath, columns)
+        public VCFParser(VCFColumns columns) : base(columns)
         { }
     }
 }

--- a/GeUtilities/IntervalParsers/VCF/VCFParserGeneric.cs
+++ b/GeUtilities/IntervalParsers/VCF/VCFParserGeneric.cs
@@ -21,12 +21,10 @@ namespace Genometric.GeUtilities.IntervalParsers
 
         #endregion
 
-        public VCFParser(string sourceFilePath) :
-            this(sourceFilePath, new VCFColumns())
+        public VCFParser() : this(new VCFColumns())
         { }
 
-        public VCFParser(string sourceFilePath, VCFColumns columns) :
-            base(sourceFilePath, columns, new VCF<I>())
+        public VCFParser(VCFColumns columns) : base(columns)
         {
             _idColumn = columns.ID; ;
             _refbColumn = columns.RefBase;
@@ -109,9 +107,9 @@ namespace Genometric.GeUtilities.IntervalParsers
             return rtv;
         }
 
-        public new VCF<I> Parse()
+        public VCF<I> Parse(string sourceFilePath)
         {
-            var rtv = (VCF<I>)base.Parse();
+            var rtv = (VCF<I>)Parse(sourceFilePath, new VCF<I>());
             Status = "100";
             return rtv;
         }


### PR DESCRIPTION
Parsers constructors have a required parameters: path the file to be parsed. Having this variable in constructor prevents using a single instance of parser to parse more than one file. Hence, the constructors of parsers and their `Parse` functions are updated to take the path parameter in the `Parse` function. This allows reusing a single parser instance for parsing multiple files. 