### PR TITLE
Assert a parsed p-value

### DIFF
--- a/GeUtilities.Tests/Intervals/Parsers/BED/ColumnsOrder.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/BED/ColumnsOrder.cs
@@ -136,10 +136,10 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.BED
             // Arrange
             string[] peaks = new string[]
             {
-                "chr1\t10\t20\t*\tGeUtilities_00\t100.0",
-                "chr1\t30\t40\t+\tGeUtilities_01\t110.0",
-                "chr1\t50\t60\t-\tGeUtilities_02\t111.0",
-                "chr1\t50\t60\t#\tGeUtilities_02\t111.0", // Any strand name other than '+', '-', and '*' will be parsed as '*'.
+                "chr1\t10\t20\t*\tGeUtilities_00\t0.1",
+                "chr1\t30\t40\t+\tGeUtilities_01\t0.11",
+                "chr1\t50\t60\t-\tGeUtilities_02\t0.111",
+                "chr1\t50\t60\t#\tGeUtilities_02\t0.111", // Any strand name other than '+', '-', and '*' will be parsed as '*'.
             };
 
             using (var file = new TempFileCreator(peaks))

--- a/GeUtilities.Tests/Intervals/Parsers/BED/Features.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/BED/Features.cs
@@ -133,10 +133,13 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.BED
         }
 
         [Theory]
-        [InlineData(-1, PValueFormats.SameAsInput)]
-        [InlineData(-1, PValueFormats.minus1_Log10_pValue)]
-        [InlineData(10000, PValueFormats.SameAsInput)]
-        public void DropPeakIfInvalidPValue(double value, PValueFormats pvalueFormat)
+        [InlineData(-1, PValueFormats.SameAsInput, true, false)]
+        [InlineData(-1, PValueFormats.SameAsInput, false, true)]
+        [InlineData(10000, PValueFormats.SameAsInput, true, false)]
+        [InlineData(10000, PValueFormats.SameAsInput, false, true)]
+        [InlineData(-1, PValueFormats.minus1_Log10_pValue, true, false)]
+        [InlineData(-1, PValueFormats.minus1_Log10_pValue, false, true)]
+        public void PValueAssertion(double value, PValueFormats pvalueFormat, bool validate, bool expected)
         {
             // Arrange
             var rg = new RegionGenerator { Value = value };
@@ -146,12 +149,13 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.BED
             {
                 var parser = new BEDParser()
                 {
-                    PValueFormat = pvalueFormat
+                    PValueFormat = pvalueFormat,
+                    ValidatePValue = validate
                 };
                 var parsedData = parser.Parse(file.Path);
 
                 // Assert
-                Assert.True(!parsedData.Chromosomes.Any());
+                Assert.True(parsedData.Chromosomes.Any() == expected);
             }
         }
 

--- a/GeUtilities.Tests/Intervals/Parsers/BED/Features.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/BED/Features.cs
@@ -134,6 +134,8 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.BED
 
         [Theory]
         [InlineData(-1, PValueFormats.SameAsInput)]
+        [InlineData(-1, PValueFormats.minus1_Log10_pValue)]
+        [InlineData(10000, PValueFormats.SameAsInput)]
         public void DropPeakIfInvalidPValue(double value, PValueFormats pvalueFormat)
         {
             // Arrange

--- a/GeUtilities.Tests/Intervals/Parsers/BED/Features.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/BED/Features.cs
@@ -8,6 +8,7 @@ using Genometric.GeUtilities.Intervals.Parsers.Model;
 using Genometric.GeUtilities.ReferenceGenomes;
 using System;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 /// <summary>
@@ -54,7 +55,7 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.BED
         public void UseDefaultPValueForPeaksWithInvalidPValue()
         {
             // Arrange
-            double defaultValue = 1122.33;
+            double defaultValue = 0.112233;
             using (var file = new TempFileCreator("chr1\t10\t20\tGeUtilities_01\t123..45"))
             {
                 // Act
@@ -128,6 +129,27 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.BED
 
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals[0].Value == originalValue);
+            }
+        }
+
+        [Theory]
+        [InlineData(-1, PValueFormats.SameAsInput)]
+        public void DropPeakIfInvalidPValue(double value, PValueFormats pvalueFormat)
+        {
+            // Arrange
+            var rg = new RegionGenerator { Value = value };
+
+            // Act
+            using (var file = new TempFileCreator(rg))
+            {
+                var parser = new BEDParser()
+                {
+                    PValueFormat = pvalueFormat
+                };
+                var parsedData = parser.Parse(file.Path);
+
+                // Assert
+                Assert.True(!parsedData.Chromosomes.Any());
             }
         }
 

--- a/GeUtilities.Tests/Intervals/Parsers/BED/RegionGenerator.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/BED/RegionGenerator.cs
@@ -131,7 +131,7 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.BED
             Right = 20;
             Summit = 15;
             Name = "GeUtilities_01";
-            Value = 123.45;
+            Value = 0.12345;
             Strand = '*';
         }
 

--- a/GeUtilities/Intervals/Parsers/BED/BEDParserGeneric.cs
+++ b/GeUtilities/Intervals/Parsers/BED/BEDParserGeneric.cs
@@ -69,6 +69,12 @@ namespace Genometric.GeUtilities.Intervals.Parsers
         public PValueFormats PValueFormat { set; get; }
 
         /// <summary>
+        /// Sets and gets if the parser should assert if 
+        /// a determined p-value falls in [0, 1] range.
+        /// </summary>
+        public bool ValidatePValue { set; get; }
+
+        /// <summary>
         /// Parse standard Browser Extensible Data (BED) format.
         /// </summary>
         /// <param name="sourceFilePath">Full path of source file name.</param>
@@ -82,6 +88,7 @@ namespace Genometric.GeUtilities.Intervals.Parsers
             _mostPermissivePeak = _constructor.Construct(0, 2, "", 1, 0);
             DefaultValue = 1E-8;
             DropPeakIfInvalidValue = true;
+            ValidatePValue = true;
             PValueFormat = PValueFormats.SameAsInput;
         }
 
@@ -118,6 +125,9 @@ namespace Genometric.GeUtilities.Intervals.Parsers
                     _defaultValueUtilizationCount++;
                 }
             }
+
+            if (ValidatePValue && (value < 0 || value > 1))
+                DropLine("\tLine " + lineCounter.ToString() + string.Format("\t:\tInvalid p-value ({0})", value));
 
             #endregion
 


### PR DESCRIPTION
With the logics implemented in this PR, user can specify if the BED parse should assert if a parsed p-value is in `[0, 1]` range. By default it does the assertion.