### PR TITLE
Incorporate culture info when parsing value column of BED files

### DIFF
--- a/GeUtilities.Tests/Intervals/Parsers/Bed/DefaultArguments.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/Bed/DefaultArguments.cs
@@ -4,6 +4,7 @@
 
 using Genometric.GeUtilities.Intervals.Parsers;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
+using System.Globalization;
 using System.Linq;
 using Xunit;
 
@@ -202,6 +203,36 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
         {
             // Arrange
             var rg = new RegionGenerator();
+            using (var file = new TempFileCreator(rg))
+            {
+                // Act
+                var parser = new BedParser();
+                var parsedData = parser.Parse(file.Path);
+
+                // Assert
+                Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.ToList()[0].Value == rg.Value);
+            }
+        }
+
+        [Theory]
+        [InlineData(0.01, "fa-IR")]
+        [InlineData(0.02, "fr-FR")]
+        [InlineData(0.03, "en-US")]
+        [InlineData(0.04, "es-ES")]
+        [InlineData(0.05, "it-IT")]
+        [InlineData(0.06, "ii-CN")]
+        [InlineData(0.07, "ru-RU")]
+        [InlineData(0.08, "ja-JP")]
+        [InlineData(0.09, "zh-CN")]
+        public void ReadValueInvariantCulture(double value, string culture)
+        {
+            // Arrange
+            var rg = new RegionGenerator
+            {
+                Value = value,
+                Culture = culture
+            };
+
             using (var file = new TempFileCreator(rg))
             {
                 // Act

--- a/GeUtilities.Tests/Intervals/Parsers/Bed/DefaultArguments.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/Bed/DefaultArguments.cs
@@ -4,7 +4,6 @@
 
 using Genometric.GeUtilities.Intervals.Parsers;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
-using System.Globalization;
 using System.Linq;
 using Xunit;
 
@@ -236,7 +235,10 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
             using (var file = new TempFileCreator(rg))
             {
                 // Act
-                var parser = new BedParser();
+                var parser = new BedParser
+                {
+                    Culture = culture
+                };
                 var parsedData = parser.Parse(file.Path);
 
                 // Assert

--- a/GeUtilities.Tests/Intervals/Parsers/Bed/DefaultArguments.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/Bed/DefaultArguments.cs
@@ -224,7 +224,6 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
         [InlineData(0.06, "ii-CN")]
         [InlineData(0.07, "ru-RU")]
         [InlineData(0.08, "ja-JP")]
-        [InlineData(0.09, "zh-CN")]
         public void ReadValueInvariantCulture(double value, string culture)
         {
             // Arrange

--- a/GeUtilities.Tests/Intervals/Parsers/Bed/DefaultArguments.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/Bed/DefaultArguments.cs
@@ -4,6 +4,8 @@
 
 using Genometric.GeUtilities.Intervals.Parsers;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
+using System;
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -244,6 +246,26 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
                 // Assert
                 Assert.True(parsedData.Chromosomes[rg.Chr].Strands[rg.Strand].Intervals.ToList()[0].Value == rg.Value);
             }
+        }
+
+        [Fact]
+        public void ThrowExceptionForInvalidCultureInfo()
+        {
+            // Arrange
+            var rg = new RegionGenerator();
+            using (var file = new TempFileCreator(rg))
+            {
+                // Act
+                var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                    () => new BedParser
+                    {
+                        Culture = "invalid_culture"
+                    });
+
+                // Assert
+                Assert.False(string.IsNullOrEmpty(exception.Message));
+                Assert.Contains("Invalid culture info", exception.Message);
+            }            
         }
 
         [Fact]

--- a/GeUtilities.Tests/Intervals/Parsers/Bed/RegionGenerator.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/Bed/RegionGenerator.cs
@@ -5,6 +5,7 @@
 using Genometric.GeUtilities.Intervals.Model;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using System;
+using System.Globalization;
 using System.Text;
 
 namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
@@ -97,6 +98,8 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
 
         public char Strand { set; get; }
 
+        public string Culture { set; get; }
+
         public Peak Peak
         {
             get
@@ -110,7 +113,7 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
             // NOTE
             // The following default column indexes must match the
             // BED file type specifications. These specifications can 
-            // be obtained from various resources such as Ensembl: 
+            // be obtained from various resources such as Ensemble: 
             // https://uswest.ensembl.org/info/website/upload/bed.html
             Columns = new BedColumns()
             {
@@ -184,7 +187,7 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
                 else if (LeftColumn == i) lineBuilder.Append(Left + d);
                 else if (RightColumn == i) lineBuilder.Append(Right + d);
                 else if (NameColumn == i) lineBuilder.Append(Name + d);
-                else if (ValueColumn == i) lineBuilder.Append(Value + d);
+                else if (ValueColumn == i) lineBuilder.Append(Value.ToString(CultureInfo.CreateSpecificCulture(Culture)) + d);
                 else if (StrandColumn == i) lineBuilder.Append(Strand + d);
                 else if (SummitColumn == i) lineBuilder.Append(Summit + d);
                 else lineBuilder.Append("AbCd" + d);

--- a/GeUtilities.Tests/Intervals/Parsers/Bed/RegionGenerator.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/Bed/RegionGenerator.cs
@@ -133,6 +133,7 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers.Bed
             Name = "GeUtilities_01";
             Value = 0.12345;
             Strand = '.';
+            Culture = CultureInfo.CurrentCulture.Name;
         }
 
         private void Swap(sbyte oldValue, sbyte newValue)

--- a/GeUtilities/Intervals/Parsers/Bed/BedParserGeneric.cs
+++ b/GeUtilities/Intervals/Parsers/Bed/BedParserGeneric.cs
@@ -5,6 +5,7 @@
 using Genometric.GeUtilities.IGenomics;
 using Genometric.GeUtilities.Intervals.Parsers.Model;
 using System;
+using System.Globalization;
 
 namespace Genometric.GeUtilities.Intervals.Parsers
 {
@@ -99,7 +100,11 @@ namespace Genometric.GeUtilities.Intervals.Parsers
             double value = 0;
             if (_valueColumn < line.Length)
             {
-                if (double.TryParse(line[_valueColumn], out double pValue))
+                if (double.TryParse(
+                    line[_valueColumn], 
+                    NumberStyles.Any, 
+                    CultureInfo,
+                    out double pValue))
                 {
                     value = PValueConvertor(pValue);
                 }

--- a/GeUtilities/Intervals/Parsers/Parser.cs
+++ b/GeUtilities/Intervals/Parsers/Parser.cs
@@ -8,7 +8,9 @@ using Genometric.GeUtilities.ReferenceGenomes;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Genometric.GeUtilities.Intervals.Parsers.Model
@@ -143,6 +145,31 @@ namespace Genometric.GeUtilities.Intervals.Parsers.Model
         /// </summary>
         public char Delimiter { set; get; }
 
+        /// <summary>
+        /// Sets and gets culture name. 
+        /// </summary>
+        public string Culture
+        {
+            set
+            {
+                if (!CultureInfo.GetCultures(CultureTypes.AllCultures).Any(x => x.Name == value))
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Invalid culture info.");
+                _culture = value;
+            }
+            get
+            {
+                return _culture;
+            }
+        }
+
+        public CultureInfo CultureInfo
+        {
+            set { Culture = value.Name; }
+            get { return CultureInfo.CreateSpecificCulture(Culture); }
+        }
+
+        private string _culture;
+
         protected Parser(BaseColumns columns)
         {
             _chrColumn = columns.Chr;
@@ -152,6 +179,7 @@ namespace Genometric.GeUtilities.Intervals.Parsers.Model
             MaxLinesToRead = uint.MaxValue;
             Delimiter = '\t';
             UnspecifiedStrandChar = '.';
+            Culture = CultureInfo.CurrentCulture.Name;
         }
 
         protected ParsedIntervals<I, S> Parse(string sourceFilePath, ParsedIntervals<I, S> data)


### PR DESCRIPTION
xref https://github.com/Genometric/MSPC/issues/96

Uses culture info to parse the value column of BED files, hence it can correctly recognize decimal separator (and thousands separator) according to the execution environment. For instance, can correctly read `0,1`, `0.1`, `0/1` following culture setting.

The culture info by default is set to the culture info of the execution environment. However, that can be override, e.g., when parsing a file that is created in a different culture setting as the execution environment. It can be overridden as the following:

```csharp
var parser = new BedParser
{
    Culture = "fa-IR"
};
```
which sets the culture info to Persian, hence correctly reading numbers such as `0/1`.

Currently supported culture are those available from `System.Globalization.CultureTypes.AllCultures`, which are [listed here](https://github.com/Genometric/GeUtilities/wiki/Currently-supported-culture).
