### PR TITLE
Handle adding two intervals with same hash key

### DIFF
--- a/GeUtilities.Tests/GeUtilities.Tests.csproj
+++ b/GeUtilities.Tests/GeUtilities.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageLicenseUrl>https://github.com/Genometric/GeUtilities/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Genometric/GeUtilities</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Genometric/GeUtilities</RepositoryUrl>
-    <Version>6.1.0</Version>
+    <Version>6.2.0</Version>
     <Description>Implements unit test functions for the GeUtilities.</Description>
     <PackageTags>genomics; genome analysis; building-blocks; parser; BED; VCF; GTF; RefSeq;</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>

--- a/GeUtilities.Tests/Intervals/Model/TestPeak.cs
+++ b/GeUtilities.Tests/Intervals/Model/TestPeak.cs
@@ -101,5 +101,39 @@ namespace Genometric.GeUtilities.Tests.Intervals.Model
             Assert.Equal(expected, actual);
             Assert.True(a.Equals(b) == equal);
         }
+
+        /// <summary>
+        /// The hash key of a peak should be computed considering 
+        /// its properties such as value, name, and summit, in 
+        /// addition to the interval properties (i.e,. left and right).
+        /// According, two peaks with same coordinates but different
+        /// properties should not have same hash key. 
+        /// </summary>
+        [Theory]
+        [InlineData(1, "a", 10, 1, "a", 10, true)]
+        [InlineData(1, "a", 10, 1, "b", 10, false)]
+        [InlineData(1, "a", 10, 1, "a", 99, false)]
+        [InlineData(1, "a", 10, 9, "a", 10, false)]
+        [InlineData(1, "a", 10, 1, "a", -1, false)]
+        [InlineData(2, "a", 10, 3, "a", 10, false)]
+        [InlineData(1, "a", -1, 1, "a", -1, true)]
+        [InlineData(1, null, -1, 1, null, -1, true)]
+        public void PeakHashKeyFuncOfPeakProperties(
+            double aValue, string aName, int aSummit, 
+            double bValue, string bName, int bSummit,
+            bool equalHashKey)
+        {
+            // Arrange
+            var peakA = new Peak(10, 20, aValue, aName, aSummit);
+            var peakB = new Peak(10, 20, bValue, bName, bSummit);
+
+            // Act
+            var peakAKey = peakA.GetHashCode();
+            var peakBKey = peakB.GetHashCode();
+            var equality = peakAKey == peakBKey;
+
+            // Assert
+            Assert.True(equality == equalHashKey);
+        }
     }
 }

--- a/GeUtilities.Tests/Intervals/Parsers/ParsedIntervals.cs
+++ b/GeUtilities.Tests/Intervals/Parsers/ParsedIntervals.cs
@@ -127,5 +127,20 @@ namespace Genometric.GeUtilities.Tests.Intervals.Parsers
                 Assert.Equal(expected, i);
             }
         }
+
+        [Fact]
+        public void ReadTwoIntervalsWithExactSameInfo()
+        {
+            // Arrange
+            var peak = "chr1\t10\t20\tGeUtilities_00\t0.01";
+            using var file = new TempFileCreator(new string[] { peak, peak });
+
+            // Act
+            var parser = new BedParser();
+            var parsedBED = parser.Parse(file.Path);
+
+            // Assert
+            Assert.True(parsedBED.IntervalsCount == 2);
+        }
     }
 }

--- a/GeUtilities/GeUtilities.csproj
+++ b/GeUtilities/GeUtilities.csproj
@@ -10,16 +10,16 @@
     <PackageProjectUrl>https://github.com/Genometric/GeUtilities</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Genometric/GeUtilities</RepositoryUrl>
     <RootNamespace>Genometric.GeUtilities</RootNamespace>
-    <Version>6.1.0</Version>
+    <Version>6.2.0</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Genometric.GeUtilities</PackageId>
     <Description>Genome Utilities (GeUtilities) provides open-source building-blocks for genomic data analysis tools.</Description>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageTags>genomics; genome analysis; building-blocks; parser; BED; VCF; GTF; RefSeq;</PackageTags>
-    <AssemblyVersion>6.1.0.0</AssemblyVersion>
+    <AssemblyVersion>6.2.0.0</AssemblyVersion>
     <PackageIconUrl>https://raw.githubusercontent.com/Genometric/GeUtilities/dev/logo/logo.png</PackageIconUrl>
-    <FileVersion>6.1.0.0</FileVersion>
+    <FileVersion>6.2.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/GeUtilities/Intervals/Genome/Chromosome.cs
+++ b/GeUtilities/Intervals/Genome/Chromosome.cs
@@ -24,8 +24,8 @@ namespace Genometric.GeUtilities.Intervals.Genome
         {
             if (!Strands.ContainsKey(strand))
                 Strands.Add(strand, new Strand<I>());
-            Strands[strand].Add(interval);
-            Statistics.Update(interval);
+            if (Strands[strand].TryAdd(interval))
+                Statistics.Update(interval);
         }
     }
 }

--- a/GeUtilities/Intervals/Genome/Strand.cs
+++ b/GeUtilities/Intervals/Genome/Strand.cs
@@ -21,9 +21,9 @@ namespace Genometric.GeUtilities.Intervals.Genome
             _intervals = new Dictionary<int, I>();
         }
 
-        public void Add(I interval)
+        public bool TryAdd(I interval)
         {
-            _intervals.Add(interval.GetHashCode(), interval);
+            return _intervals.TryAdd(interval.GetHashCode(), interval);
         }
 
         public bool TryGet(int hashkey, out I interval)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # Common configuration for all branches
-version: '6.1.{build}'
+version: '6.2.{build}'
 image: Visual Studio 2019
 
 init:


### PR DESCRIPTION
(may answer https://github.com/Genometric/MSPC/issues/123)

The probability of two intervals having same hash key is very low, because the interval key is generated  as a function of the following properties: left and right coordinates, value, name, summit, and line number. 

1. Line number is passed as hash seed:
https://github.com/Genometric/GeUtilities/blob/08fca1d453ba52158042916d72aa526e68d10c84/GeUtilities/Intervals/Parsers/Parser.cs#L264-L267

2. then value, summit, and name are appended to the line number as hash seed: 
https://github.com/Genometric/GeUtilities/blob/08fca1d453ba52158042916d72aa526e68d10c84/GeUtilities/Intervals/Model/Peak.cs#L11-L12

3. then the seed is used together with left and right values to generated has value: 
https://github.com/Genometric/GeUtilities/blob/08fca1d453ba52158042916d72aa526e68d10c84/GeUtilities/Intervals/Model/Interval.cs#L17-L20

This setup decrease the probability of two equal strings passed to the `FNVHashFunction` function, hence very low probability of two interval having same hash key. However, this PR makes necessary changes to handle the cases where two interval might have same hash key. 
